### PR TITLE
Add config.go and delete sample functions in sabakan/main.go

### DIFF
--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	var e etcdConfig
 	e.Servers = strings.Split(*flagEtcdServers, ",")
-	e.Prefix = *flagEtcdPrefix
+	e.Prefix = "/" + *flagEtcdPrefix
 
 	cfg := clientv3.Config{
 		Endpoints: e.Servers,
@@ -40,7 +40,7 @@ func main() {
 	}
 
 	r := mux.NewRouter()
-	sabakan.InitConfig(r.PathPrefix("/api/v1/").Subrouter(), c)
+	sabakan.InitConfig(r.PathPrefix("/api/v1/").Subrouter(), c, e.Prefix)
 
 	s := &cmd.HTTPServer{
 		Server: &http.Server{

--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -9,28 +9,19 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/sabakan"
 	"github.com/gorilla/mux"
 )
 
 var (
-	flagHTTP           = flag.String("http", "0.0.0.0:8888", "<Listen IP>:<Port number>")
-	flagEtcdServers    = flag.String("etcd-servers", "http://localhost:2379", "URLs of the backend etcd")
-	flagEtcdPrefix     = flag.String("etcd-prefix", "", "etcd prefix")
-	flagNodeIPv4Offset = flag.String("node-ipv4-offset", "", "IP address offset to assign Nodes")
-	flagNodeRackShift  = flag.String("node-rack-shift", "", "Integer to calculate IP addresses for address each nodes based on --node-ipv4-offset")
-	flagBMCIPv4Offset  = flag.String("bmc-ipv4-offset", "", "IP address offset to assign Baseboard Management Controller")
-	flagBMCRackShift   = flag.String("bmc-rack-shift", "", "Integer to calculate IP addresses for address each BMC based on --bmc-ipv4-offset")
-	flagNodeIPPerNode  = flag.String("node-ip-per-node", "1", "Number of IP addresses per node. Exclude BMC. Default to 1")
-	flagBMCPerNode     = flag.String("bmc-ip-per-node", "1", "Number of IP addresses per BMC. Default to 1")
+	flagHTTP        = flag.String("http", "0.0.0.0:8888", "<Listen IP>:<Port number>")
+	flagEtcdServers = flag.String("etcd-servers", "http://localhost:2379", "URLs of the backend etcd")
+	flagEtcdPrefix  = flag.String("etcd-prefix", "", "etcd prefix")
 )
 
 type etcdConfig struct {
 	Servers []string
 	Prefix  string
-}
-
-type etcdClient struct {
-	c *clientv3.Client
 }
 
 func main() {
@@ -49,7 +40,7 @@ func main() {
 	}
 
 	r := mux.NewRouter()
-	initHello(r.PathPrefix("/").Subrouter(), c)
+	sabakan.InitConfig(r.PathPrefix("/api/v1/").Subrouter(), c)
 
 	s := &cmd.HTTPServer{
 		Server: &http.Server{
@@ -64,22 +55,4 @@ func main() {
 	if err != nil && !cmd.IsSignaled(err) {
 		log.ErrorExit(err)
 	}
-}
-
-func (e *etcdClient) initHelloFunc(r *mux.Router) {
-	r.HandleFunc("/hello", e.handleHello).Methods("GET")
-}
-
-func initHello(r *mux.Router, c *clientv3.Client) {
-	e := &etcdClient{c}
-	e.initHelloFunc(r)
-}
-
-func (e *etcdClient) handleHello(w http.ResponseWriter, r *http.Request) {
-	_, err := e.c.Put(r.Context(), "/world", "Hello, world v3")
-	if err != nil {
-		w.Write([]byte(err.Error() + "\n"))
-		return
-	}
-	w.Write([]byte("Hello, world\n"))
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,153 @@
+package sabakan
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/gorilla/mux"
+)
+
+// SabakanConfig is structure of the sabakan option
+type sabakanConfig struct {
+	NodeIPv4Offset string `json:"node-ipv4-offset"`
+	NodeRackShift  uint   `json:"node-rack-shift"`
+	BMCIPv4Offset  string `json:"bmc-ipv4-offset"`
+	BMCRackShift   uint   `json:"bmc-rack-shift"`
+	NodeIPPerNode  uint   `json:"node-ip-per-node"`
+	BMCIPPerNode   uint   `json:"bmc-ip-per-node"`
+}
+
+// etcdClient is etcd3 client object
+type etcdClient struct {
+	c *clientv3.Client
+}
+
+const (
+	// EtcdKeyConfig is etcd key name for sabakan option
+	EtcdKeyConfig = "/config"
+	// EtcdKeyMachines is etcd key name for machines management
+	EtcdKeyMachines = "/machines"
+
+	// ErrorValueNotFound is an error message when a target value is not found
+	ErrorValueNotFound = "Value not found"
+	// ErrorMachinesExist is an error message when /machines key exists in etcd.
+	ErrorMachinesExist = "Machines already exist"
+	// ErrorValueAlreadyExists is an error message when a target value already exists
+	ErrorValueAlreadyExists = "Value already exists"
+)
+
+// InitConfig is initialization of the sabakan API /config
+func InitConfig(r *mux.Router, c *clientv3.Client) {
+	e := &etcdClient{c}
+	e.initConfigFunc(r)
+}
+
+func (e *etcdClient) initConfigFunc(r *mux.Router) {
+	r.HandleFunc("/config", e.handleGetConfig).Methods("GET")
+	r.HandleFunc("/config", e.handlePostConfig).Methods("POST")
+}
+
+func (e *etcdClient) handleGetConfig(w http.ResponseWriter, r *http.Request) {
+	resp, err := e.c.Get(r.Context(), EtcdKeyConfig)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if resp == nil {
+		http.Error(w, ErrorValueNotFound, http.StatusNotFound)
+		return
+	}
+	if len(resp.Kvs) == 0 {
+		http.Error(w, ErrorValueNotFound, http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(resp.Kvs[0].Value)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (e *etcdClient) handlePostConfig(w http.ResponseWriter, r *http.Request) {
+	resp, err := e.c.Get(r.Context(), EtcdKeyMachines, clientv3.WithPrefix())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if resp.Count != 0 {
+		http.Error(w, ErrorMachinesExist, http.StatusForbidden)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	var sc sabakanConfig
+
+	fmt.Println(r.Body)
+	b, _ := ioutil.ReadAll(r.Body)
+	err = json.Unmarshal(b, &sc)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	// Validation
+	if sc.NodeIPv4Offset == "" {
+		http.Error(w, "node-ipv4-offset: "+ErrorValueNotFound, http.StatusBadRequest)
+		return
+	}
+	if sc.NodeRackShift == 0 {
+		http.Error(w, "node-rack-shift: "+ErrorValueNotFound, http.StatusBadRequest)
+		return
+	}
+	if sc.BMCIPv4Offset == "" {
+		http.Error(w, "bmc-ipv4-offset: "+ErrorValueNotFound, http.StatusBadRequest)
+		return
+	}
+	if sc.BMCRackShift == 0 {
+		http.Error(w, "bmc-rack-shift: "+ErrorValueNotFound, http.StatusBadRequest)
+		return
+	}
+	if sc.NodeIPPerNode == 0 {
+		http.Error(w, "node-ip-per-node: "+ErrorValueNotFound, http.StatusBadRequest)
+		return
+	}
+	if sc.BMCIPPerNode == 0 {
+		http.Error(w, "bmc-ip-per-node: "+ErrorValueNotFound, http.StatusBadRequest)
+		return
+	}
+
+	j, err := json.Marshal(sc)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Add config if /config doesn't exist.
+	_, err = e.c.Txn(r.Context()).
+		If(clientv3.Compare(clientv3.CreateRevision(EtcdKeyConfig), "=", 0)).
+		Then(clientv3.OpPut(EtcdKeyConfig, string(j))).
+		Else().
+		Commit()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Add config if value of the /config is not same.
+	_, err = e.c.Txn(r.Context()).
+		If(clientv3.Compare(clientv3.Value(EtcdKeyConfig), "!=", string(j))).
+		Then(clientv3.OpPut(EtcdKeyConfig, string(j))).
+		Else().
+		Commit()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/responses.go
+++ b/responses.go
@@ -1,0 +1,24 @@
+package sabakan
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cybozu-go/log"
+)
+
+func respError(w http.ResponseWriter, resperr error, status int) {
+	out, err := json.Marshal(map[string]interface{}{
+		"error": resperr.Error(),
+	})
+	if err != nil {
+		log.Error(err.Error(), nil)
+		return
+	}
+
+	log.Error(resperr.Error(), nil)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	fmt.Fprintf(w, string(out))
+}


### PR DESCRIPTION
- sabakan command line options which are used on the IP adddress
  calculation of the machine registration is saved in the etcd for
  distributing other etcd members. sabakan daemon requires only listen
  address and etcd connection parameters.
- Delete initHello() as sample handler.