### PR TITLE
Crypts API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ jobs:
     working_directory: /go/src/github.com/cybozu-go/sabakan
     steps:
       - checkout
-      - run: curl -L http://localhost:2379/health
       - run: go get github.com/golang/lint/golint
       - run: go get golang.org/x/tools/cmd/goimports
       - run: (! $GOPATH/bin/goimports -d . 2>&1 | read _)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,11 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1-stretch
+      - image: quay.io/coreos/etcd:v3.3
     working_directory: /go/src/github.com/cybozu-go/sabakan
     steps:
       - checkout
+      - run: curl -L http://localhost:2379/health
       - run: go get github.com/golang/lint/golint
       - run: go get golang.org/x/tools/cmd/goimports
       - run: (! $GOPATH/bin/goimports -d . 2>&1 | read _)

--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -40,8 +40,9 @@ func main() {
 	}
 
 	r := mux.NewRouter()
-	sabakan.InitConfig(r.PathPrefix("/api/v1/").Subrouter(), c, e.Prefix)
-	sabakan.InitCrypts(r.PathPrefix("/api/v1/").Subrouter(), c, e.Prefix)
+	etcdClient := &sabakan.EtcdClient{Client: c, Prefix: e.Prefix}
+	sabakan.InitConfig(r.PathPrefix("/api/v1/").Subrouter(), etcdClient)
+	sabakan.InitCrypts(r.PathPrefix("/api/v1/").Subrouter(), etcdClient)
 
 	s := &cmd.HTTPServer{
 		Server: &http.Server{

--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/sabakan"
 	"github.com/gorilla/mux"
 )
 
@@ -50,6 +51,7 @@ func main() {
 
 	r := mux.NewRouter()
 	initHello(r.PathPrefix("/").Subrouter(), c)
+	sabakan.InitCrypts(r.PathPrefix("/api/v1/crypts").Subrouter(), c)
 
 	s := &cmd.HTTPServer{
 		Server: &http.Server{

--- a/config.go
+++ b/config.go
@@ -20,10 +20,10 @@ type sabakanConfig struct {
 	BMCIPPerNode   uint   `json:"bmc-ip-per-node"`
 }
 
-// etcdClient is etcd3 client object
-type etcdClient struct {
-	client *clientv3.Client
-	prefix string
+// EtcdClient is etcd3 Client object
+type EtcdClient struct {
+	Client *clientv3.Client
+	Prefix string
 }
 
 const (
@@ -38,24 +38,21 @@ const (
 	ErrorValueNotFound = "value not found"
 	// ErrorMachinesExist is an error message when /machines key exists in etcd.
 	ErrorMachinesExist = "machines already exist"
-	// ErrorCryptsExist is an error message when /crypts key exists in etcd.
-	ErrorCryptsExist = "crypts already exist"
 )
 
 // InitConfig is initialization of the sabakan API /config
-func InitConfig(r *mux.Router, c *clientv3.Client, p string) {
-	e := &etcdClient{c, p}
+func InitConfig(r *mux.Router, e *EtcdClient) {
 	e.initConfigFunc(r)
 }
 
-func (e *etcdClient) initConfigFunc(r *mux.Router) {
+func (e *EtcdClient) initConfigFunc(r *mux.Router) {
 	r.HandleFunc("/config", e.handleGetConfig).Methods("GET")
 	r.HandleFunc("/config", e.handlePostConfig).Methods("POST")
 }
 
-func (e *etcdClient) handleGetConfig(w http.ResponseWriter, r *http.Request) {
-	key := path.Join(e.prefix, EtcdKeyConfig)
-	resp, err := e.client.Get(r.Context(), key)
+func (e *EtcdClient) handleGetConfig(w http.ResponseWriter, r *http.Request) {
+	key := path.Join(e.Prefix, EtcdKeyConfig)
+	resp, err := e.Client.Get(r.Context(), key)
 	if err != nil {
 		respError(w, err, http.StatusInternalServerError)
 		return
@@ -78,9 +75,9 @@ func (e *etcdClient) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (e *etcdClient) handlePostConfig(w http.ResponseWriter, r *http.Request) {
-	key := path.Join(e.prefix, EtcdKeyMachines)
-	resp, err := e.client.Get(r.Context(), key, clientv3.WithPrefix())
+func (e *EtcdClient) handlePostConfig(w http.ResponseWriter, r *http.Request) {
+	key := path.Join(e.Prefix, EtcdKeyMachines)
+	resp, err := e.Client.Get(r.Context(), key, clientv3.WithPrefix())
 	if err != nil {
 		respError(w, err, http.StatusInternalServerError)
 		return
@@ -131,8 +128,8 @@ func (e *etcdClient) handlePostConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Put config
-	key = path.Join(e.prefix, EtcdKeyConfig)
-	_, err = e.client.Put(r.Context(), key, string(j))
+	key = path.Join(e.Prefix, EtcdKeyConfig)
+	_, err = e.Client.Put(r.Context(), key, string(j))
 	if err != nil {
 		respError(w, err, http.StatusInternalServerError)
 		return

--- a/config.go
+++ b/config.go
@@ -31,13 +31,15 @@ const (
 	EtcdKeyConfig = "/config"
 	// EtcdKeyMachines is etcd key name for machines management
 	EtcdKeyMachines = "/machines"
+	// EtcdKeyCrypts is etcd key name for crypts management
+	EtcdKeyCrypts = "/crypts"
 
 	// ErrorValueNotFound is an error message when a target value is not found
-	ErrorValueNotFound = "Value not found"
+	ErrorValueNotFound = "value not found"
 	// ErrorMachinesExist is an error message when /machines key exists in etcd.
-	ErrorMachinesExist = "Machines already exist"
-	// ErrorValueAlreadyExists is an error message when a target value already exists
-	ErrorValueAlreadyExists = "Value already exists"
+	ErrorMachinesExist = "machines already exist"
+	// ErrorCryptsExist is an error message when /crypts key exists in etcd.
+	ErrorCryptsExist = "crypts already exist"
 )
 
 // InitConfig is initialization of the sabakan API /config

--- a/config.go
+++ b/config.go
@@ -54,15 +54,15 @@ func (e *EtcdClient) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	key := path.Join(e.Prefix, EtcdKeyConfig)
 	resp, err := e.Client.Get(r.Context(), key)
 	if err != nil {
-		respError(w, err, http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 	if resp == nil {
-		respError(w, errors.New(ErrorValueNotFound), http.StatusNotFound)
+		renderError(w, errors.New(ErrorValueNotFound), http.StatusNotFound)
 		return
 	}
 	if len(resp.Kvs) == 0 {
-		respError(w, errors.New(ErrorValueNotFound), http.StatusNotFound)
+		renderError(w, errors.New(ErrorValueNotFound), http.StatusNotFound)
 		return
 	}
 
@@ -70,7 +70,7 @@ func (e *EtcdClient) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(resp.Kvs[0].Value)
 	if err != nil {
-		respError(w, err, http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 }
@@ -79,11 +79,11 @@ func (e *EtcdClient) handlePostConfig(w http.ResponseWriter, r *http.Request) {
 	key := path.Join(e.Prefix, EtcdKeyMachines)
 	resp, err := e.Client.Get(r.Context(), key, clientv3.WithPrefix())
 	if err != nil {
-		respError(w, err, http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 	if resp.Count != 0 {
-		respError(w, errors.New(ErrorMachinesExist), http.StatusForbidden)
+		renderError(w, errors.New(ErrorMachinesExist), http.StatusForbidden)
 		return
 	}
 
@@ -92,38 +92,38 @@ func (e *EtcdClient) handlePostConfig(w http.ResponseWriter, r *http.Request) {
 
 	err = json.NewDecoder(r.Body).Decode(&sc)
 	if err != nil {
-		respError(w, err, http.StatusBadRequest)
+		renderError(w, err, http.StatusBadRequest)
 		return
 	}
 	// Validation
 	if sc.NodeIPv4Offset == "" {
-		respError(w, errors.New("node-ipv4-offset: "+ErrorValueNotFound), http.StatusBadRequest)
+		renderError(w, errors.New("node-ipv4-offset: "+ErrorValueNotFound), http.StatusBadRequest)
 		return
 	}
 	if sc.NodeRackShift == 0 {
-		respError(w, errors.New("node-rack-shift: "+ErrorValueNotFound), http.StatusBadRequest)
+		renderError(w, errors.New("node-rack-shift: "+ErrorValueNotFound), http.StatusBadRequest)
 		return
 	}
 	if sc.BMCIPv4Offset == "" {
-		respError(w, errors.New("bmc-ipv4-offset: "+ErrorValueNotFound), http.StatusBadRequest)
+		renderError(w, errors.New("bmc-ipv4-offset: "+ErrorValueNotFound), http.StatusBadRequest)
 		return
 	}
 	if sc.BMCRackShift == 0 {
-		respError(w, errors.New("bmc-rack-shift: "+ErrorValueNotFound), http.StatusBadRequest)
+		renderError(w, errors.New("bmc-rack-shift: "+ErrorValueNotFound), http.StatusBadRequest)
 		return
 	}
 	if sc.NodeIPPerNode == 0 {
-		respError(w, errors.New("node-ip-per-node: "+ErrorValueNotFound), http.StatusBadRequest)
+		renderError(w, errors.New("node-ip-per-node: "+ErrorValueNotFound), http.StatusBadRequest)
 		return
 	}
 	if sc.BMCIPPerNode == 0 {
-		respError(w, errors.New("bmc-ip-per-node: "+ErrorValueNotFound), http.StatusBadRequest)
+		renderError(w, errors.New("bmc-ip-per-node: "+ErrorValueNotFound), http.StatusBadRequest)
 		return
 	}
 
 	j, err := json.Marshal(sc)
 	if err != nil {
-		respError(w, err, http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -131,7 +131,7 @@ func (e *EtcdClient) handlePostConfig(w http.ResponseWriter, r *http.Request) {
 	key = path.Join(e.Prefix, EtcdKeyConfig)
 	_, err = e.Client.Put(r.Context(), key, string(j))
 	if err != nil {
-		respError(w, err, http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 

--- a/crypts.go
+++ b/crypts.go
@@ -1,11 +1,15 @@
 package sabakan
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 
+	"io/ioutil"
+
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/gorilla/mux"
 )
 
@@ -20,7 +24,7 @@ type etcdClient struct {
 
 func (e *etcdClient) initCryptsFunc(r *mux.Router) {
 	r.HandleFunc("/{serial}/{path}", e.handleCryptsGet).Methods("GET")
-	//r.HandleFunc("/{serial}/", e.handleCryptsPost).Methods("POST")
+	r.HandleFunc("/{serial}", e.handleCryptsPost).Methods("POST")
 }
 
 func InitCrypts(r *mux.Router, c *clientv3.Client) {
@@ -30,37 +34,116 @@ func InitCrypts(r *mux.Router, c *clientv3.Client) {
 
 func (e *etcdClient) handleCryptsGet(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
+	serial := vars["serial"]
+	path := vars["path"]
+
 	resp, err := e.c.Get(r.Context(),
-		fmt.Sprintf("/crypts/%v/%v", vars["serial"], vars["path"]))
+		fmt.Sprintf("/crypts/%v/%v", serial, path))
+	if err != nil {
+		w.Write([]byte(err.Error() + "\n"))
+		return
+	}
+	if len(resp.Kvs) == 0 {
+		w.WriteHeader(404)
+		return
+	}
+	if len(resp.Kvs) != 1 {
+		w.WriteHeader(500)
+		return
+	}
+
+	ev := resp.Kvs[0]
+	entity := &cryptEntity{
+		Path: string(path),
+		Key:  string(ev.Value)}
+	res, err := json.Marshal(entity)
 	if err != nil {
 		w.Write([]byte(err.Error() + "\n"))
 		return
 	}
 
-	if len(resp.Kvs) == 0 {
-		w.WriteHeader(404)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(res)
+}
+
+func (e *etcdClient) handleCryptsPost(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	serial := vars["serial"]
+	var receivedEntity cryptEntity
+	b, _ := ioutil.ReadAll(r.Body)
+	json.Unmarshal(b, &receivedEntity)
+	path := receivedEntity.Path
+	key := receivedEntity.Key
+
+	s, err := concurrency.NewSession(e.c)
+	defer s.Close()
+	if err != nil {
+		w.Write([]byte(err.Error() + "\n"))
+		return
+	}
+	m := concurrency.NewMutex(s, "/sabakan-post-crypts-lock/")
+	if err := m.Lock(context.TODO()); err != nil {
+		w.Write([]byte(err.Error() + "\n"))
 		return
 	}
 
-	for _, ev := range resp.Kvs {
-		entity := &cryptEntity{
-			Path: string(vars["path"]),
-			Key:  string(ev.Value)}
-
-		res, err := json.Marshal(entity)
-		if err != nil {
-			w.Write([]byte(err.Error() + "\n"))
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(res)
+	// Prohibit overwriting
+	check, err := e.c.Get(r.Context(),
+		fmt.Sprintf("/crypts/%v/%v", serial, path))
+	if err != nil {
+		w.Write([]byte(err.Error() + "\n"))
+		return
 	}
-}
+	if len(check.Kvs) == 1 {
+		w.WriteHeader(400)
+		return
+	}
 
-//func (e *etcdClient) handleCryptsPost(w http.ResponseWriter, r *http.Request) {
-//	vars := mux.Vars(r)
-//	resp, err := e.c.Put(r.Context(),
-//		fmt.Sprintf("/crypts/%v/%v", vars["serial"], vars["path"]))
-//
-//}
+	// Put crypts on etcd
+	resp, err := e.c.Put(r.Context(),
+		fmt.Sprintf("/crypts/%v/%v", serial, path),
+		key)
+	if err != nil && resp != nil {
+		w.Write([]byte(err.Error() + "\n"))
+		return
+	}
+
+	// Confirm whether it was saved in etcd
+	check, err = e.c.Get(r.Context(),
+		fmt.Sprintf("/crypts/%v/%v", serial, path))
+	if err != nil {
+		w.Write([]byte(err.Error() + "\n"))
+		return
+	}
+	if len(check.Kvs) == 0 {
+		w.WriteHeader(404)
+		return
+	}
+	if len(check.Kvs) != 1 {
+		w.WriteHeader(500)
+		return
+	}
+	ev := check.Kvs[0]
+	savedKey := string(ev.Value)
+	if savedKey != key {
+		w.WriteHeader(500)
+		return
+	}
+
+	if err := m.Unlock(context.TODO()); err != nil {
+		w.WriteHeader(500)
+		return
+	}
+
+	responseEntity := &cryptEntity{
+		Path: string(path),
+		Key:  string(savedKey)}
+	res, err := json.Marshal(responseEntity)
+	if err != nil {
+		w.Write([]byte(err.Error() + "\n"))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+	w.Write(res)
+}

--- a/crypts.go
+++ b/crypts.go
@@ -1,1 +1,66 @@
 package sabakan
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/gorilla/mux"
+)
+
+type cryptEntity struct {
+	Path string `json:"path"`
+	Key  string `json:"key"`
+}
+
+type etcdClient struct {
+	c *clientv3.Client
+}
+
+func (e *etcdClient) initCryptsFunc(r *mux.Router) {
+	r.HandleFunc("/{serial}/{path}", e.handleCryptsGet).Methods("GET")
+	//r.HandleFunc("/{serial}/", e.handleCryptsPost).Methods("POST")
+}
+
+func InitCrypts(r *mux.Router, c *clientv3.Client) {
+	e := &etcdClient{c}
+	e.initCryptsFunc(r)
+}
+
+func (e *etcdClient) handleCryptsGet(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	resp, err := e.c.Get(r.Context(),
+		fmt.Sprintf("/crypts/%v/%v", vars["serial"], vars["path"]))
+	if err != nil {
+		w.Write([]byte(err.Error() + "\n"))
+		return
+	}
+
+	if len(resp.Kvs) == 0 {
+		w.WriteHeader(404)
+		return
+	}
+
+	for _, ev := range resp.Kvs {
+		entity := &cryptEntity{
+			Path: string(vars["path"]),
+			Key:  string(ev.Value)}
+
+		res, err := json.Marshal(entity)
+		if err != nil {
+			w.Write([]byte(err.Error() + "\n"))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(res)
+	}
+}
+
+//func (e *etcdClient) handleCryptsPost(w http.ResponseWriter, r *http.Request) {
+//	vars := mux.Vars(r)
+//	resp, err := e.c.Put(r.Context(),
+//		fmt.Sprintf("/crypts/%v/%v", vars["serial"], vars["path"]))
+//
+//}

--- a/crypts.go
+++ b/crypts.go
@@ -145,9 +145,7 @@ func (e *EtcdClient) handleDeleteCrypts(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// DELETE
-	_, err = e.Client.Delete(r.Context(),
-		target,
-		clientv3.WithPrefix())
+	_, err = e.Client.Delete(r.Context(), target, clientv3.WithPrefix())
 	if err != nil {
 		respError(w, err, http.StatusInternalServerError)
 		return

--- a/crypts.go
+++ b/crypts.go
@@ -5,11 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-
 	"path"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/clientv3/concurrency"
+	"github.com/coreos/etcd/clientv3/clientv3util"
 	"github.com/gorilla/mux"
 )
 
@@ -27,12 +26,11 @@ type (
 )
 
 // InitCrypts initialize the handle functions for crypts
-func InitCrypts(r *mux.Router, c *clientv3.Client, p string) {
-	e := &etcdClient{c, p}
+func InitCrypts(r *mux.Router, e *EtcdClient) {
 	e.initCryptsFunc(r)
 }
 
-func (e *etcdClient) initCryptsFunc(r *mux.Router) {
+func (e *EtcdClient) initCryptsFunc(r *mux.Router) {
 	r.HandleFunc("/crypts/{serial}/{path}", e.handleGetCrypts).Methods("GET")
 	r.HandleFunc("/crypts/{serial}", e.handlePostCrypts).Methods("POST")
 	r.HandleFunc("/crypts/{serial}", e.handleDeleteCrypts).Methods("DELETE")
@@ -58,13 +56,13 @@ func validatePostParams(received sabakanCrypt) error {
 	return nil
 }
 
-func (e *etcdClient) handleGetCrypts(w http.ResponseWriter, r *http.Request) {
+func (e *EtcdClient) handleGetCrypts(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	serial := vars["serial"]
 	diskPath := vars["path"]
 
-	target := path.Join(e.prefix, EtcdKeyCrypts, serial, diskPath)
-	resp, err := e.client.Get(r.Context(), target)
+	target := path.Join(e.Prefix, EtcdKeyCrypts, serial, diskPath)
+	resp, err := e.Client.Get(r.Context(), target)
 	if err != nil {
 		respError(w, err, http.StatusInternalServerError)
 		return
@@ -87,7 +85,7 @@ func (e *etcdClient) handleGetCrypts(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (e *etcdClient) handlePostCrypts(w http.ResponseWriter, r *http.Request) {
+func (e *EtcdClient) handlePostCrypts(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	serial := vars["serial"]
 	var received sabakanCrypt
@@ -99,52 +97,26 @@ func (e *etcdClient) handlePostCrypts(w http.ResponseWriter, r *http.Request) {
 	diskPath := received.Path
 	key := received.Key
 
-	// Validation
 	if err := validatePostParams(received); err != nil {
 		respError(w, err, http.StatusBadRequest)
 		return
 	}
 
-	//  Start mutex
-	s, err := concurrency.NewSession(e.client)
-	defer s.Close()
+	target := path.Join(e.Prefix, EtcdKeyCrypts, serial, diskPath)
+	val, err := json.Marshal(sabakanCrypt{Path: diskPath, Key: key})
+
+	tresp, err := e.Client.Txn(r.Context()).
+		// Prohibit overwriting
+		If(clientv3util.KeyMissing(target)).
+		Then(clientv3.OpPut(target, string(val))).
+		Else().
+		Commit()
 	if err != nil {
 		respError(w, err, http.StatusInternalServerError)
 		return
 	}
-	m := concurrency.NewMutex(s, "/sabakan-post-crypts-lock/")
-	if err := m.Lock(r.Context()); err != nil {
-		respError(w, err, http.StatusInternalServerError)
-		return
-	}
-
-	// Prohibit overwriting
-	target := path.Join(e.prefix, EtcdKeyCrypts, serial, diskPath)
-	prev, err := e.client.Get(r.Context(), target)
-	if err != nil {
-		w.Write([]byte(err.Error() + "\n"))
-		return
-	}
-	if prev.Count >= 1 {
-		respError(w, fmt.Errorf(ErrorCryptsExist), http.StatusBadRequest)
-		return
-	}
-
-	// Put crypts on etcd
-	crypt := sabakanCrypt{Path: diskPath, Key: key}
-	val, err := json.Marshal(crypt)
-	if err != nil {
-		respError(w, err, http.StatusInternalServerError)
-		return
-	}
-	if _, err := e.client.Put(r.Context(), target, string(val)); err != nil {
-		respError(w, err, http.StatusInternalServerError)
-		return
-	}
-
-	// Close mutex
-	if err := m.Unlock(r.Context()); err != nil {
-		respError(w, err, http.StatusInternalServerError)
+	if !tresp.Succeeded {
+		respError(w, fmt.Errorf("transaction failed. sabakan prohibits overwriting crypts"), http.StatusInternalServerError)
 		return
 	}
 
@@ -154,13 +126,13 @@ func (e *etcdClient) handlePostCrypts(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (e *etcdClient) handleDeleteCrypts(w http.ResponseWriter, r *http.Request) {
+func (e *EtcdClient) handleDeleteCrypts(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	serial := vars["serial"]
-	target := path.Join(e.prefix, EtcdKeyCrypts, serial)
+	target := path.Join(e.Prefix, EtcdKeyCrypts, serial)
 
 	// Confirm the targets exist
-	gresp, err := e.client.Get(r.Context(),
+	gresp, err := e.Client.Get(r.Context(),
 		target,
 		clientv3.WithPrefix())
 	if err != nil {
@@ -173,7 +145,7 @@ func (e *etcdClient) handleDeleteCrypts(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// DELETE
-	_, err = e.client.Delete(r.Context(),
+	_, err = e.Client.Delete(r.Context(),
 		target,
 		clientv3.WithPrefix())
 	if err != nil {

--- a/crypts_test.go
+++ b/crypts_test.go
@@ -1,18 +1,218 @@
 package sabakan
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"reflect"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/gorilla/mux"
+)
+
+var (
+	flagEtcdServers = flag.String("etcd-servers", "http://localhost:2379", "URLs of the backend etcd")
+	flagEtcdPrefix  = flag.String("etcd-prefix", "/sabakan-test", "etcd prefix")
+)
+
+func TestMain(m *testing.M) {
+	err := setupEtcd()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
+
+func setupEtcd() error {
+	etcd, err := newEtcdClient()
+	if err != nil {
+		return err
+	}
+	defer etcd.Close()
+
+	_, err = etcd.Delete(context.Background(), *flagEtcdPrefix, clientv3.WithPrefix())
+	return err
+}
+
+func newEtcdClient() (*clientv3.Client, error) {
+	return clientv3.New(clientv3.Config{
+		Endpoints:   strings.Split(*flagEtcdServers, ","),
+		DialTimeout: 2 * time.Second,
+	})
+}
 
 func TestValidatePostParams(t *testing.T) {
-	valid := sabakanCrypt{"disk-a", "fooo"}
+	valid := sabakanCrypt{"disk-a", "foo"}
 	if err := validatePostParams(valid); err != nil {
 		t.Fatal("validator should return nil when the args are valid.")
 	}
-	invalid1 := sabakanCrypt{"", "fooo"}
+	invalid1 := sabakanCrypt{"", "foo"}
 	if err := validatePostParams(invalid1); err == nil {
 		t.Fatal("validator should return error when the args are valid.")
 	}
 	invalid2 := sabakanCrypt{"disk-a", ""}
 	if err := validatePostParams(invalid2); err == nil {
 		t.Fatal("validator should return error when the args are valid.")
+	}
+}
+
+func TestHandleGetCrypts(t *testing.T) {
+	etcd, _ := newEtcdClient()
+	defer etcd.Close()
+	prefix := *flagEtcdPrefix + "/TestHandleGetCrypts"
+	etcdClient := EtcdClient{etcd, prefix}
+	serial := "1"
+	diskPath := "exists-path"
+	key := "aaa"
+	crypt := sabakanCrypt{Path: diskPath, Key: key}
+	val, _ := json.Marshal(crypt)
+	etcd.Put(context.Background(), path.Join(prefix, "crypts", serial, diskPath), string(val))
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", path.Join("/api/v1/crypts", serial, diskPath), nil)
+	r = mux.SetURLVars(r, map[string]string{"serial": serial, "path": diskPath})
+
+	etcdClient.handleGetCrypts(w, r)
+
+	resp := w.Result()
+	var sut sabakanCrypt
+	json.NewDecoder(resp.Body).Decode(&sut)
+	if resp.StatusCode != 200 {
+		t.Fatal("expected: 200, actual:", resp.StatusCode)
+	}
+	if sut != crypt {
+		t.Fatal("invalid response body, ", sut)
+	}
+}
+
+func TestHandleGetCryptsNotFound(t *testing.T) {
+	etcd, _ := newEtcdClient()
+	defer etcd.Close()
+	etcdClient := EtcdClient{etcd, *flagEtcdPrefix + "/TestHandleGetCryptsNotFound"}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/crypts", nil)
+	r = mux.SetURLVars(r, map[string]string{"serial": "1", "path": "non-exists-key"})
+
+	etcdClient.handleGetCrypts(w, r)
+
+	resp := w.Result()
+	if resp.StatusCode != 404 {
+		t.Fatal("expected: 404, actual:", resp.StatusCode)
+	}
+}
+
+func TestHandlePostCrypts(t *testing.T) {
+	etcd, _ := newEtcdClient()
+	defer etcd.Close()
+	prefix := *flagEtcdPrefix + "/TestHandlePostCrypts"
+	etcdClient := EtcdClient{etcd, prefix}
+	serial := "1"
+	diskPath := "put-path"
+	key := "aaa"
+	crypt := sabakanCrypt{Path: diskPath, Key: key}
+	val, _ := json.Marshal(crypt)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", path.Join("/api/v1/crypts", serial), bytes.NewBuffer(val))
+	r = mux.SetURLVars(r, map[string]string{"serial": serial})
+
+	etcdClient.handlePostCrypts(w, r)
+
+	resp := w.Result()
+	var responsedCrypt sabakanCrypt
+	var savedCrypt sabakanCrypt
+	json.NewDecoder(resp.Body).Decode(&responsedCrypt)
+	etcdResp, _ := etcd.Get(context.Background(), path.Join(prefix, EtcdKeyCrypts, serial, diskPath))
+	json.Unmarshal(etcdResp.Kvs[0].Value, &savedCrypt)
+	if resp.StatusCode != 201 {
+		t.Fatal("expected: 201, actual:", resp.StatusCode)
+	}
+	if responsedCrypt != crypt {
+		t.Fatal("invalid response body, ", responsedCrypt)
+	}
+	if savedCrypt != crypt {
+		t.Fatal("saved entity is invalid, ", savedCrypt)
+	}
+}
+
+func TestHandlePostCryptsInvalidBody(t *testing.T) {
+	etcd, _ := newEtcdClient()
+	defer etcd.Close()
+	etcdClient := EtcdClient{etcd, *flagEtcdPrefix + "/TestHandlePostCryptsInvalidBody"}
+	w := httptest.NewRecorder()
+	invalidBody, _ := json.Marshal(&struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}{"Taro", 1})
+	r := httptest.NewRequest("POST", "/api/v1/crypts/1", bytes.NewBuffer(invalidBody))
+	r = mux.SetURLVars(r, map[string]string{"serial": "1"})
+
+	etcdClient.handlePostCrypts(w, r)
+
+	resp := w.Result()
+	if w.Result().StatusCode != 400 {
+		t.Fatal("expected: 400, actual:", resp.StatusCode)
+	}
+}
+
+func TestHandleDeleteCrypts(t *testing.T) {
+	etcd, _ := newEtcdClient()
+	defer etcd.Close()
+	prefix := *flagEtcdPrefix + "/TestHandleDeleteCrypts"
+	etcdClient := EtcdClient{etcd, prefix}
+	expectedResponse := deleteResponse{}
+	serial := "1"
+	key := "aaa"
+	for i := 0; i < 5; i++ {
+		diskPath := "path" + strconv.Itoa(i)
+		crypt := sabakanCrypt{Path: diskPath, Key: key}
+		val, _ := json.Marshal(crypt)
+		target := path.Join(prefix, EtcdKeyCrypts, serial, diskPath)
+		etcd.Put(context.Background(), target, string(val))
+		expectedResponse = append(expectedResponse, deletePath{target})
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("DELETE", path.Join("/api/v1/crypts", serial), nil)
+	r = mux.SetURLVars(r, map[string]string{"serial": serial})
+
+	etcdClient.handleDeleteCrypts(w, r)
+
+	resp := w.Result()
+	var sut deleteResponse
+	json.NewDecoder(resp.Body).Decode(&sut)
+	etcdResp, _ := etcd.Get(context.Background(), path.Join(prefix, EtcdKeyCrypts, serial), clientv3.WithPrefix())
+	if resp.StatusCode != 200 {
+		t.Fatal("expected: 200, actual:", resp.StatusCode)
+	}
+	if etcdResp.Count != 0 {
+		t.Fatal("expected: 0, actual:", etcdResp.Count)
+	}
+	if !reflect.DeepEqual(sut, expectedResponse) {
+		t.Fatal("unexpected response:", sut)
+	}
+}
+
+func TestHandleDeleteCryptsNotFound(t *testing.T) {
+	etcd, _ := newEtcdClient()
+	defer etcd.Close()
+	etcdClient := EtcdClient{etcd, *flagEtcdPrefix + "/TestHandleDeleteCryptsNotFound"}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("DELETE", "/api/v1/crypts", nil)
+	r = mux.SetURLVars(r, map[string]string{"serial": "non-exists-serial"})
+
+	etcdClient.handleDeleteCrypts(w, r)
+
+	resp := w.Result()
+	if resp.StatusCode != 404 {
+		t.Fatal("expected: 404, actual:", resp.StatusCode)
 	}
 }

--- a/crypts_test.go
+++ b/crypts_test.go
@@ -2,17 +2,17 @@ package sabakan
 
 import "testing"
 
-func Test_validatePostParams(t *testing.T) {
-	validEntity := cryptEntity{"disk-a", "fooo"}
-	if err := validatePostParams(validEntity); err != nil {
+func TestValidatePostParams(t *testing.T) {
+	valid := sabakanCrypt{"disk-a", "fooo"}
+	if err := validatePostParams(valid); err != nil {
 		t.Fatal("validator should return nil when the args are valid.")
 	}
-	invalidEntity1 := cryptEntity{"", "fooo"}
-	if err := validatePostParams(invalidEntity1); err == nil {
+	invalid1 := sabakanCrypt{"", "fooo"}
+	if err := validatePostParams(invalid1); err == nil {
 		t.Fatal("validator should return error when the args are valid.")
 	}
-	invalidEntity2 := cryptEntity{"disk-a", ""}
-	if err := validatePostParams(invalidEntity2); err == nil {
+	invalid2 := sabakanCrypt{"disk-a", ""}
+	if err := validatePostParams(invalid2); err == nil {
 		t.Fatal("validator should return error when the args are valid.")
 	}
 }

--- a/crypts_test.go
+++ b/crypts_test.go
@@ -1,0 +1,27 @@
+package sabakan
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_respWritr(t *testing.T) {
+	w := httptest.NewRecorder()
+	entity := cryptEntity{Path: "path", Key: "aaa"}
+	respWriter(w, entity, http.StatusCreated)
+	resp := w.Result()
+	var sut cryptEntity
+	json.NewDecoder(resp.Body).Decode(&sut)
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatal("expected 201. actual: ", resp.StatusCode)
+	}
+	if resp.Header.Get("Content-Type") != "application/json" {
+		t.Fatal("expected application/json")
+	}
+	if sut == entity {
+		t.Fatal("invalid response body")
+	}
+}

--- a/crypts_test.go
+++ b/crypts_test.go
@@ -1,0 +1,18 @@
+package sabakan
+
+import "testing"
+
+func Test_validatePostParams(t *testing.T) {
+	validEntity := cryptEntity{"disk-a", "fooo"}
+	if err := validatePostParams(validEntity); err != nil {
+		t.Fatal("validator should return nil when the args are valid.")
+	}
+	invalidEntity1 := cryptEntity{"", "fooo"}
+	if err := validatePostParams(invalidEntity1); err == nil {
+		t.Fatal("validator should return error when the args are valid.")
+	}
+	invalidEntity2 := cryptEntity{"disk-a", ""}
+	if err := validatePostParams(invalidEntity2); err == nil {
+		t.Fatal("validator should return error when the args are valid.")
+	}
+}

--- a/crypts_test.go
+++ b/crypts_test.go
@@ -4,10 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"flag"
-	"fmt"
 	"net/http/httptest"
-	"os"
 	"path"
 	"reflect"
 	"strconv"
@@ -16,20 +13,6 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/gorilla/mux"
 )
-
-var (
-	flagEtcdServers = flag.String("etcd-servers", "http://localhost:2379", "URLs of the backend etcd")
-	flagEtcdPrefix  = flag.String("etcd-prefix", "/sabakan-test", "etcd prefix")
-)
-
-func TestMain(m *testing.M) {
-	err := setupEtcd()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	os.Exit(m.Run())
-}
 
 func TestValidatePostParams(t *testing.T) {
 	valid := sabakanCrypt{"disk-a", "foo"}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,27 @@
+package sabakan
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+)
+
+func setupEtcd() error {
+	etcd, err := newEtcdClient()
+	if err != nil {
+		return err
+	}
+	defer etcd.Close()
+
+	_, err = etcd.Delete(context.Background(), *flagEtcdPrefix, clientv3.WithPrefix())
+	return err
+}
+
+func newEtcdClient() (*clientv3.Client, error) {
+	return clientv3.New(clientv3.Config{
+		Endpoints:   strings.Split(*flagEtcdServers, ","),
+		DialTimeout: 2 * time.Second,
+	})
+}

--- a/main_test.go
+++ b/main_test.go
@@ -2,11 +2,29 @@ package sabakan
 
 import (
 	"context"
+	"flag"
+	"fmt"
+	"os"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
 )
+
+var (
+	flagEtcdServers = flag.String("etcd-servers", "http://localhost:2379", "URLs of the backend etcd")
+	flagEtcdPrefix  = flag.String("etcd-prefix", "/sabakan-test", "etcd prefix")
+)
+
+func TestMain(m *testing.M) {
+	err := setupEtcd()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
 
 func setupEtcd() error {
 	etcd, err := newEtcdClient()

--- a/responses.go
+++ b/responses.go
@@ -4,37 +4,32 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"fmt"
-
-	"strings"
-
-	"strconv"
-
 	"github.com/cybozu-go/log"
 )
 
-func respWriter(w http.ResponseWriter, data interface{}, status int) error {
+func renderJSON(w http.ResponseWriter, data interface{}, status int) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	out, err := json.Marshal(data)
-	outstr := string(out)
-	log.Info(strings.Join([]string{"status:", strconv.Itoa(status), ", response_body:", outstr}, " "), nil)
-	fmt.Fprintf(w, outstr)
+	err := json.NewEncoder(w).Encode(data)
 	if err != nil {
 		return err
 	}
-	return nil
+	return err
 }
 
-func respError(w http.ResponseWriter, resperr error, status int) {
+func renderError(w http.ResponseWriter, resperr error, status int) {
 	out := map[string]interface{}{
 		"error": resperr.Error(),
 	}
-	log.Error(resperr.Error(), nil)
+	log.Error("an error occurred during request processing", map[string]interface{}{
+		"error": resperr.Error(),
+	})
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	err := json.NewEncoder(w).Encode(out)
 	if err != nil {
-		log.Error(err.Error(), nil)
+		log.Error("failed to encode error to JSON", map[string]interface{}{
+			"error": err.Error(),
+		})
 	}
 }

--- a/responses.go
+++ b/responses.go
@@ -11,9 +11,6 @@ func renderJSON(w http.ResponseWriter, data interface{}, status int) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	err := json.NewEncoder(w).Encode(data)
-	if err != nil {
-		return err
-	}
 	return err
 }
 

--- a/responses.go
+++ b/responses.go
@@ -4,13 +4,22 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"fmt"
+
+	"strings"
+
+	"strconv"
+
 	"github.com/cybozu-go/log"
 )
 
 func respWriter(w http.ResponseWriter, data interface{}, status int) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	err := json.NewEncoder(w).Encode(data)
+	out, err := json.Marshal(data)
+	outstr := string(out)
+	log.Info(strings.Join([]string{"status:", strconv.Itoa(status), ", response_body:", outstr}, " "), nil)
+	fmt.Fprintf(w, outstr)
 	if err != nil {
 		return err
 	}

--- a/responses.go
+++ b/responses.go
@@ -2,35 +2,30 @@ package sabakan
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/cybozu-go/log"
 )
 
 func respWriter(w http.ResponseWriter, data interface{}, status int) error {
-	b, err := json.Marshal(data)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	err := json.NewEncoder(w).Encode(data)
 	if err != nil {
 		return err
 	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	w.Write(b)
 	return nil
 }
 
 func respError(w http.ResponseWriter, resperr error, status int) {
-	out, err := json.Marshal(map[string]interface{}{
+	out := map[string]interface{}{
 		"error": resperr.Error(),
-	})
-	if err != nil {
-		log.Error(err.Error(), nil)
-		return
 	}
-
 	log.Error(resperr.Error(), nil)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	fmt.Fprintf(w, string(out))
+	err := json.NewEncoder(w).Encode(out)
+	if err != nil {
+		log.Error(err.Error(), nil)
+	}
 }

--- a/responses_test.go
+++ b/responses_test.go
@@ -11,11 +11,14 @@ import (
 
 func TestRespWriter(t *testing.T) {
 	w := httptest.NewRecorder()
-	crypt := sabakanCrypt{Path: "path", Key: "aaa"}
-	respWriter(w, crypt, http.StatusCreated)
+	inputCrypt := sabakanCrypt{Path: "path", Key: "aaa"}
+	renderJSON(w, inputCrypt, http.StatusCreated)
 	resp := w.Result()
-	var sut sabakanCrypt
-	json.NewDecoder(resp.Body).Decode(&sut)
+	var outputCrypt sabakanCrypt
+	err := json.NewDecoder(resp.Body).Decode(&outputCrypt)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatal("expected 201. actual: ", resp.StatusCode)
@@ -23,7 +26,7 @@ func TestRespWriter(t *testing.T) {
 	if resp.Header.Get("Content-Type") != "application/json" {
 		t.Fatal("expected application/json")
 	}
-	if sut != crypt {
+	if outputCrypt != inputCrypt {
 		t.Fatal("invalid response body")
 	}
 }
@@ -31,9 +34,12 @@ func TestRespWriter(t *testing.T) {
 func TestRespError(t *testing.T) {
 	w := httptest.NewRecorder()
 	resperr := fmt.Errorf("test")
-	respError(w, resperr, http.StatusBadRequest)
+	renderError(w, resperr, http.StatusBadRequest)
 	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatal("expected 400. actual: ", resp.StatusCode)

--- a/responses_test.go
+++ b/responses_test.go
@@ -2,6 +2,8 @@ package sabakan
 
 import (
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,5 +25,24 @@ func Test_respWriter(t *testing.T) {
 	}
 	if sut != entity {
 		t.Fatal("invalid response body")
+	}
+}
+
+func Test_respError(t *testing.T) {
+	w := httptest.NewRecorder()
+	resperr := fmt.Errorf("test")
+	respError(w, resperr, http.StatusBadRequest)
+	resp := w.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatal("expected 400. actual: ", resp.StatusCode)
+	}
+	if resp.Header.Get("Content-Type") != "application/json" {
+		t.Fatal("expected application/json")
+	}
+	expected := "{\"error\":\"test\"}"
+	if string(body) != expected {
+		t.Fatal("invalid response body, ", string(expected))
 	}
 }

--- a/responses_test.go
+++ b/responses_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 )
 
-func Test_respWriter(t *testing.T) {
+func TestRespWriter(t *testing.T) {
 	w := httptest.NewRecorder()
-	entity := cryptEntity{Path: "path", Key: "aaa"}
-	respWriter(w, entity, http.StatusCreated)
+	crypt := sabakanCrypt{Path: "path", Key: "aaa"}
+	respWriter(w, crypt, http.StatusCreated)
 	resp := w.Result()
-	var sut cryptEntity
+	var sut sabakanCrypt
 	json.NewDecoder(resp.Body).Decode(&sut)
 
 	if resp.StatusCode != http.StatusCreated {
@@ -23,12 +23,12 @@ func Test_respWriter(t *testing.T) {
 	if resp.Header.Get("Content-Type") != "application/json" {
 		t.Fatal("expected application/json")
 	}
-	if sut != entity {
+	if sut != crypt {
 		t.Fatal("invalid response body")
 	}
 }
 
-func Test_respError(t *testing.T) {
+func TestRespError(t *testing.T) {
 	w := httptest.NewRecorder()
 	resperr := fmt.Errorf("test")
 	respError(w, resperr, http.StatusBadRequest)
@@ -41,8 +41,8 @@ func Test_respError(t *testing.T) {
 	if resp.Header.Get("Content-Type") != "application/json" {
 		t.Fatal("expected application/json")
 	}
-	expected := "{\"error\":\"test\"}"
+	expected := "{\"error\":\"test\"}\n"
 	if string(body) != expected {
-		t.Fatal("invalid response body, ", string(expected))
+		t.Fatal("actual:", string(body), ", expected:", expected)
 	}
 }


### PR DESCRIPTION
**What this PR does**

Implement the following API

- GET `/crypts/<serial>/<path`
- DELETE `/crypts/<serial>`
- POST `/crypts/<serial>`

---

Let all response Content-Type are `application/json`.

## POST /api/v1/crypts/<serial>

Add crypt key for the encrypted disk.

### request body schema:

```json
{"path": <path>,"key": <key>} 
```

### Response
- status code : 201 Created
- response body 
    - ```json
      {"path": <path>, "key": <key>}
      ```
### Error cases
- invalid params (400)
- `/<prefix>/crypts/<serial>/<path>` already exists in etcd (400)

## example

```console
$ curl -i -X POST \
     -H "Content-Type:application/json" \
     -d \
  '{"key": "key101", "path":"aaaaa"}' \
   'http://localhost:8888/api/v1/crypts/1'
HTTP/1.1 201 Created
Content-Type: application/json
Date: Tue, 10 Apr 2018 09:12:12 GMT
Content-Length: 31

{"path":"aaaaa","key":"key101"}
```
---

## GET `/api/v1/crypts/<serial>/<path>`

Get specific crypts key.

### Response
- 200 OK
- response body
    ```json
    {"path": <path>,"key": <key>}
    ```

### Error cases
- `/<prefix>/crypts/<serial>/<path>` is not found in etcd (404)

### Example

```console
$ curl -i -X GET \
   'http://localhost:8888/api/v1/crypts/1/aaaaa'
HTTP/1.1 200 OK
Content-Type: application/json
Date: Tue, 10 Apr 2018 09:15:59 GMT
Content-Length: 31

{"path":"aaaaa","key":"key101"}
```

---

## DELETE `/api/v1/crypts/<serial>`

Delete all keys of the specified machine.

### Response
- 200OK
- Response body is the array of deleted keys

### Error cases
- `/<prefix>/crypts/<serial>/<path>` is not found in etcd (404)

### Example

```console
$ curl -i -X DELETE \
   'http://localhost:8888/api/v1/crypts/1'
HTTP/1.1 200 OK
Content-Type: application/json
Date: Tue, 10 Apr 2018 09:19:01 GMT
Content-Length: 51

[{"path":"/crypts/1/a"},{"path":"/crypts/1/aaaaa"}]
```

## etcd
- `<prefix>/crypts/<serial>/<path>`
    - prefix: string specified by option `--etcd-prefix`
    - serial: serial number of the machine
    - path: the disk name in `/dev/disk/by-path`

```console
$ etcdctl get sabakan/crypts/1234abcd/pci-0000:00:1f.2-ata-3
1234abcd/pci-0000:00:1f.2-ata-3
{ 
  "path": "pci-0000:00:1f.2-ata-3",
  "key": "g2iLHLXxpVOZ6swjGpESmAhdzQu2YtOa"
}
```