### PR TITLE
Allow binary data for disk encryption keys.

### DIFF
--- a/responses_test.go
+++ b/responses_test.go
@@ -6,16 +6,18 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
 
 func TestRespWriter(t *testing.T) {
 	w := httptest.NewRecorder()
-	inputCrypt := sabakanCrypt{Path: "path", Key: "aaa"}
-	renderJSON(w, inputCrypt, http.StatusCreated)
+	input := map[string]string{"Path": "path", "Key": "aaa"}
+	renderJSON(w, input, http.StatusCreated)
 	resp := w.Result()
-	var outputCrypt sabakanCrypt
-	err := json.NewDecoder(resp.Body).Decode(&outputCrypt)
+	var output map[string]string
+	err := json.NewDecoder(resp.Body).Decode(&output)
+	resp.Body.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +28,7 @@ func TestRespWriter(t *testing.T) {
 	if resp.Header.Get("Content-Type") != "application/json" {
 		t.Fatal("expected application/json")
 	}
-	if outputCrypt != inputCrypt {
+	if !reflect.DeepEqual(input, output) {
 		t.Fatal("invalid response body")
 	}
 }


### PR DESCRIPTION
Disk encryption keys are likely binary data.
sabakan should accept them.

Changes:
* Replace POST handler with PUT to accept binary keys.
* Change GET response to send binary key.
* Simplify DELETE implementation.
* Fix TOCTTOU bug in DELETE.
* Rewrote tests.