### PR TITLE
[etcd] revamp watch implementation.

### DIFF
--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"path"
 	"strings"
 	"time"
 
@@ -46,7 +47,7 @@ func main() {
 
 	var e etcdConfig
 	e.Servers = strings.Split(*flagEtcdServers, ",")
-	e.Prefix = "/" + *flagEtcdPrefix
+	e.Prefix = path.Clean("/" + *flagEtcdPrefix)
 
 	timeout, err := time.ParseDuration(*flagEtcdTimeout)
 	if err != nil {

--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net"
@@ -68,7 +69,12 @@ func main() {
 	defer c2.Close()
 
 	model := etcd.NewModel(c, c2, e.Prefix)
-	cmd.Go(model.Run)
+	ch := make(chan struct{})
+	cmd.Go(func(ctx context.Context) error {
+		return model.Run(ctx, ch)
+	})
+	// waiting the driver gets ready
+	<-ch
 
 	leaser := mock.NewLeaser(dhcp4Begin, dhcp4End)
 	dhcps := dhcp4.New(*flagDHCPBind, *flagDHCPInterface, *flagDHCPIPXEFirmware, leaser)

--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -63,13 +63,8 @@ func main() {
 		log.ErrorExit(err)
 	}
 	defer c.Close()
-	c2, err := clientv3.New(cfg)
-	if err != nil {
-		log.ErrorExit(err)
-	}
-	defer c2.Close()
 
-	model := etcd.NewModel(c, c2, e.Prefix)
+	model := etcd.NewModel(c, e.Prefix)
 	ch := make(chan struct{})
 	cmd.Go(func(ctx context.Context) error {
 		return model.Run(ctx, ch)

--- a/e2e/sabactl_test.go
+++ b/e2e/sabactl_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/cybozu-go/sabakan"
 	"github.com/cybozu-go/sabakan/client"
@@ -60,6 +61,8 @@ func testSabactlDHCP(t *testing.T) {
 		t.Fatal("exit code:", code)
 	}
 
+	time.Sleep(100 * time.Millisecond)
+
 	stdout, stderr, err = runSabactl("dhcp", "get")
 	code = exitCode(err)
 	if code != client.ExitSuccess {
@@ -106,6 +109,8 @@ func testSabactlIPAM(t *testing.T) {
 		t.Error("stderr:", stderr.String())
 		t.Fatal("exit code:", code)
 	}
+
+	time.Sleep(100 * time.Millisecond)
 
 	stdout, stderr, err = runSabactl("ipam", "get")
 	code = exitCode(err)
@@ -163,6 +168,8 @@ func testSabactlMachines(t *testing.T) {
 		t.Error("stderr:", stderr.String())
 		t.Fatal("exit code:", code)
 	}
+
+	time.Sleep(100 * time.Millisecond)
 
 	machines := []sabakan.Machine{
 		{

--- a/model.go
+++ b/model.go
@@ -31,21 +31,29 @@ type MachineModel interface {
 // IPAMModel is an interface for IPAMConfig.
 type IPAMModel interface {
 	PutConfig(ctx context.Context, config *IPAMConfig) error
-	GetConfig(ctx context.Context) (*IPAMConfig, error)
+	GetConfig() (*IPAMConfig, error)
 }
 
 // DHCPModel is an interface for DHCPConfig.
 type DHCPModel interface {
 	PutConfig(ctx context.Context, config *DHCPConfig) error
-	GetConfig(ctx context.Context) (*DHCPConfig, error)
+	GetConfig() (*DHCPConfig, error)
 	Lease(ctx context.Context, ifaddr net.IP, mac net.HardwareAddr) (net.IP, error)
 	Renew(ctx context.Context, ciaddr net.IP, mac net.HardwareAddr) error
 	Release(ctx context.Context, ciaddr net.IP, mac net.HardwareAddr) error
 }
 
 // Runner is an interface to run the underlying threads.
+//
+// The caller must pass a channel as follows.
+// Receiving a value from the channel effectively guarantees that
+// the driver gets ready.
+//
+//    ch := make(chan struct{})
+//    cmd.Go(driver.Run, ch)
+//    <-ch
 type Runner interface {
-	Run(ctx context.Context) error
+	Run(ctx context.Context, ch chan<- struct{}) error
 }
 
 // Model is a struct that consists of sub-models.

--- a/model.go
+++ b/model.go
@@ -50,7 +50,9 @@ type DHCPModel interface {
 // the driver gets ready.
 //
 //    ch := make(chan struct{})
-//    cmd.Go(driver.Run, ch)
+//    cmd.Go(func(ctx context.Context) error {
+//        driver.Run(ctx, ch)
+//    })
 //    <-ch
 type Runner interface {
 	Run(ctx context.Context, ch chan<- struct{}) error

--- a/models/etcd/dhcp_test.go
+++ b/models/etcd/dhcp_test.go
@@ -17,12 +17,13 @@ var testDHCPConfig = sabakan.DHCPConfig{
 }
 
 func testDHCPPutConfig(t *testing.T) {
-	d := testNewDriver(t)
+	d, ch := testNewDriver(t)
 	config := &testDHCPConfig
 	err := d.putDHCPConfig(context.Background(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
+	<-ch
 
 	resp, err := d.client.Get(context.Background(), t.Name()+KeyDHCP)
 	if err != nil {
@@ -44,7 +45,7 @@ func testDHCPPutConfig(t *testing.T) {
 }
 
 func testDHCPGetConfig(t *testing.T) {
-	d := testNewDriver(t)
+	d, ch := testNewDriver(t)
 
 	config := &testDHCPConfig
 
@@ -56,17 +57,19 @@ func testDHCPGetConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	<-ch
 
-	actual, err := d.getDHCPConfig(context.Background())
+	actual, err := d.getDHCPConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if !reflect.DeepEqual(config, actual) {
 		t.Errorf("unexpected loaded config %#v", actual)
 	}
 }
 
-func testSetupConfig(t *testing.T, d *driver) {
+func testSetupConfig(t *testing.T, d *driver, ch <-chan struct{}) {
 	ipam := &testIPAMConfig
 	config := &testDHCPConfig
 
@@ -74,17 +77,19 @@ func testSetupConfig(t *testing.T, d *driver) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	<-ch
 
 	err = d.putDHCPConfig(context.Background(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
+	<-ch
 }
 
 func testDHCPLease(t *testing.T) {
-	d := testNewDriver(t)
+	d, ch := testNewDriver(t)
 
-	testSetupConfig(t, d)
+	testSetupConfig(t, d, ch)
 
 	interfaceip := net.ParseIP("10.69.0.195")
 	mac := net.HardwareAddr([]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66})
@@ -142,9 +147,9 @@ func testDHCPLease(t *testing.T) {
 }
 
 func testDHCPRenew(t *testing.T) {
-	d := testNewDriver(t)
+	d, ch := testNewDriver(t)
 
-	testSetupConfig(t, d)
+	testSetupConfig(t, d, ch)
 
 	leasedip := net.ParseIP("10.69.0.224")
 	mac := net.HardwareAddr([]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66})
@@ -166,9 +171,9 @@ func testDHCPRenew(t *testing.T) {
 }
 
 func testDHCPRelease(t *testing.T) {
-	d := testNewDriver(t)
+	d, ch := testNewDriver(t)
 
-	testSetupConfig(t, d)
+	testSetupConfig(t, d, ch)
 
 	interfaceip := net.ParseIP("10.69.0.195")
 	mac := net.HardwareAddr([]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66})

--- a/models/etcd/driver.go
+++ b/models/etcd/driver.go
@@ -3,21 +3,29 @@ package etcd
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/cybozu-go/sabakan"
 )
 
 type driver struct {
-	client  *clientv3.Client
-	watcher *clientv3.Client
-	prefix  string
-	mi      *machinesIndex
+	client     *clientv3.Client
+	watcher    *clientv3.Client
+	prefix     string
+	mi         *machinesIndex
+	ipamConfig atomic.Value
+	dhcpConfig atomic.Value
 }
 
 // NewModel returns sabakan.Model
 func NewModel(client, watcher *clientv3.Client, prefix string) sabakan.Model {
-	d := &driver{client, watcher, prefix, newMachinesIndex()}
+	d := &driver{
+		client:  client,
+		watcher: watcher,
+		prefix:  prefix,
+		mi:      newMachinesIndex(),
+	}
 	return sabakan.Model{
 		Runner:  d,
 		Storage: d,
@@ -28,6 +36,6 @@ func NewModel(client, watcher *clientv3.Client, prefix string) sabakan.Model {
 }
 
 // Run starts etcd watcher.  This should be called as a goroutine.
-func (d *driver) Run(ctx context.Context) error {
-	return d.startWatching(ctx)
+func (d *driver) Run(ctx context.Context, ch chan<- struct{}) error {
+	return d.startWatching(ctx, ch)
 }

--- a/models/etcd/ipam_test.go
+++ b/models/etcd/ipam_test.go
@@ -22,12 +22,13 @@ var testIPAMConfig = sabakan.IPAMConfig{
 }
 
 func testIPAMPutConfig(t *testing.T) {
-	d := testNewDriver(t)
+	d, ch := testNewDriver(t)
 	config := &testIPAMConfig
 	err := d.putIPAMConfig(context.Background(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
+	<-ch
 
 	resp, err := d.client.Get(context.Background(), t.Name()+KeyIPAM)
 	if err != nil {
@@ -58,7 +59,7 @@ func testIPAMPutConfig(t *testing.T) {
 }
 
 func testIPAMGetConfig(t *testing.T) {
-	d := testNewDriver(t)
+	d, ch := testNewDriver(t)
 
 	config := &testIPAMConfig
 
@@ -70,11 +71,13 @@ func testIPAMGetConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	<-ch
 
-	actual, err := d.getIPAMConfig(context.Background())
+	actual, err := d.getIPAMConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if !reflect.DeepEqual(config, actual) {
 		t.Errorf("unexpected loaded config %#v", actual)
 	}

--- a/models/etcd/machine.go
+++ b/models/etcd/machine.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"path"
 
 	"github.com/coreos/etcd/clientv3"
@@ -16,12 +15,9 @@ import (
 func (d *driver) Register(ctx context.Context, machines []*sabakan.Machine) error {
 	wmcs := make([]*sabakan.Machine, len(machines))
 
-	cfg, err := d.getIPAMConfig(ctx)
+	cfg, err := d.getIPAMConfig()
 	if err != nil {
 		return err
-	}
-	if cfg == nil {
-		return errors.New("IPAM configuration not found")
 	}
 
 RETRY:

--- a/models/etcd/machine_test.go
+++ b/models/etcd/machine_test.go
@@ -4,19 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
-	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/sabakan"
 )
 
 func testRegister(t *testing.T) {
-	d := testNewDriver(t)
+	d, ch := testNewDriver(t)
 	config := &testIPAMConfig
 	err := d.putIPAMConfig(context.Background(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
+	<-ch
 
 	machines := []*sabakan.Machine{
 		&sabakan.Machine{
@@ -97,22 +96,20 @@ func testRegister(t *testing.T) {
 }
 
 func testQuery(t *testing.T) {
-	d := testNewDriver(t)
-	cmd.Go(d.Run)
-	time.Sleep(1 * time.Millisecond)
+	d, ch := testNewDriver(t)
 
 	config := &testIPAMConfig
 	err := d.putIPAMConfig(context.Background(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
+	<-ch
 
 	machines := []*sabakan.Machine{
 		&sabakan.Machine{Serial: "12345678", Product: "R630", Role: "worker"},
 		&sabakan.Machine{Serial: "12345679", Product: "R630", Role: "worker"},
 		&sabakan.Machine{Serial: "12345680", Product: "R730", Role: "worker"},
 	}
-	time.Sleep(1 * time.Millisecond)
 	err = d.Register(context.Background(), machines)
 	if err != nil {
 		t.Fatal(err)
@@ -144,12 +141,13 @@ func testQuery(t *testing.T) {
 }
 
 func testDelete(t *testing.T) {
-	d := testNewDriver(t)
+	d, ch := testNewDriver(t)
 	config := &testIPAMConfig
 	err := d.putIPAMConfig(context.Background(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
+	<-ch
 
 	machines := []*sabakan.Machine{
 		&sabakan.Machine{

--- a/models/etcd/main_test.go
+++ b/models/etcd/main_test.go
@@ -74,15 +74,10 @@ func testNewDriver(t *testing.T) (*driver, <-chan struct{}) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	watcher, err := newEtcdClient()
-	if err != nil {
-		t.Fatal(err)
-	}
 	d := &driver{
-		client:  client,
-		watcher: watcher,
-		prefix:  t.Name(),
-		mi:      newMachinesIndex(),
+		client: client,
+		prefix: t.Name(),
+		mi:     newMachinesIndex(),
 	}
 	ch := make(chan struct{}, 1)
 	go d.startWatching(context.Background(), ch)

--- a/models/etcd/storage_test.go
+++ b/models/etcd/storage_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestStorage(t *testing.T) {
-	d := testNewDriver(t)
+	d, _ := testNewDriver(t)
 
 	err := d.PutEncryptionKey(context.Background(), "1234", "abcd-efgh", []byte("data"))
 	if err != nil {

--- a/models/etcd/watch.go
+++ b/models/etcd/watch.go
@@ -1,0 +1,104 @@
+package etcd
+
+import (
+	"context"
+	"encoding/json"
+	"path"
+	"strings"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/cybozu-go/sabakan"
+)
+
+func (d *driver) initIPAMConfig(ctx context.Context) error {
+	ipamKey := path.Join(d.prefix, KeyIPAM)
+	resp, err := d.watcher.Get(ctx, ipamKey)
+	if err != nil {
+		return err
+	}
+	if len(resp.Kvs) == 0 {
+		return nil
+	}
+
+	config := new(sabakan.IPAMConfig)
+	err = json.Unmarshal(resp.Kvs[0].Value, config)
+	if err != nil {
+		return err
+	}
+
+	d.ipamConfig.Store(config)
+	return nil
+}
+
+func (d *driver) initDHCPConfig(ctx context.Context) error {
+	dhcpKey := path.Join(d.prefix, KeyDHCP)
+	resp, err := d.watcher.Get(ctx, dhcpKey)
+	if err != nil {
+		return err
+	}
+	if len(resp.Kvs) == 0 {
+		return nil
+	}
+
+	config := new(sabakan.DHCPConfig)
+	err = json.Unmarshal(resp.Kvs[0].Value, config)
+	if err != nil {
+		return err
+	}
+
+	d.dhcpConfig.Store(config)
+	return nil
+}
+
+func (d *driver) startWatching(ctx context.Context, ch chan<- struct{}) error {
+	// obtain the current revision to avoid missing events.
+	resp, err := d.watcher.Get(ctx, "/")
+	if err != nil {
+		return err
+	}
+	rev := resp.Header.Revision
+
+	err = d.initIPAMConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = d.initDHCPConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = d.mi.init(ctx, d.watcher, d.prefix)
+	if err != nil {
+		return err
+	}
+
+	// notify the caller of the readiness
+	ch <- struct{}{}
+
+	rch := d.watcher.Watch(ctx, d.prefix, clientv3.WithPrefix(), clientv3.WithPrevKV(), clientv3.WithRev(rev))
+	for wresp := range rch {
+		for _, ev := range wresp.Events {
+			var err error
+			key := string(ev.Kv.Key[len(d.prefix):])
+			switch {
+			case strings.HasPrefix(key, KeyMachines):
+				err = d.handleMachines(ev)
+			case key == KeyDHCP:
+				err = d.handleDHCPConfig(ev)
+			case key == KeyIPAM:
+				err = d.handleIPAMConfig(ev)
+			}
+			if err != nil {
+				panic(err)
+			} else {
+				select {
+				case ch <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/models/mock/driver.go
+++ b/models/mock/driver.go
@@ -14,8 +14,8 @@ type driver struct {
 	storage  map[string][]byte
 	machines map[string]*sabakan.Machine
 	leases   map[string]*leaseUsage
-	ipam     sabakan.IPAMConfig
-	dhcp     sabakan.DHCPConfig
+	ipam     *sabakan.IPAMConfig
+	dhcp     *sabakan.DHCPConfig
 }
 
 // NewModel returns sabakan.Model
@@ -34,6 +34,7 @@ func NewModel() sabakan.Model {
 	}
 }
 
-func (d *driver) Run(ctx context.Context) error {
+func (d *driver) Run(ctx context.Context, ch chan<- struct{}) error {
+	ch <- struct{}{}
 	return nil
 }

--- a/models/mock/ipam.go
+++ b/models/mock/ipam.go
@@ -14,14 +14,18 @@ func (d *driver) putIPAMConfig(ctx context.Context, config *sabakan.IPAMConfig) 
 	if len(d.machines) > 0 {
 		return errors.New("machines already exist")
 	}
-	d.ipam = *config
+	copied := *config
+	d.ipam = &copied
 	return nil
 }
 
-func (d *driver) getIPAMConfig(ctx context.Context) (*sabakan.IPAMConfig, error) {
+func (d *driver) getIPAMConfig() (*sabakan.IPAMConfig, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	copied := d.ipam
+	if d.ipam == nil {
+		return nil, errors.New("IPAMConfig is not set")
+	}
+	copied := *d.ipam
 	return &copied, nil
 }
 
@@ -33,6 +37,6 @@ func (d ipamDriver) PutConfig(ctx context.Context, config *sabakan.IPAMConfig) e
 	return d.putIPAMConfig(ctx, config)
 }
 
-func (d ipamDriver) GetConfig(ctx context.Context) (*sabakan.IPAMConfig, error) {
-	return d.getIPAMConfig(ctx)
+func (d ipamDriver) GetConfig() (*sabakan.IPAMConfig, error) {
+	return d.getIPAMConfig()
 }

--- a/web/dhcp.go
+++ b/web/dhcp.go
@@ -22,12 +22,8 @@ func (s Server) handleConfigDHCP(w http.ResponseWriter, r *http.Request) {
 
 func (s Server) handleConfigDHCPGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	config, err := s.Model.DHCP.GetConfig(ctx)
+	config, err := s.Model.DHCP.GetConfig()
 	if err != nil {
-		renderError(ctx, w, InternalServerError(err))
-		return
-	}
-	if config == nil {
 		renderError(ctx, w, APIErrNotFound)
 		return
 	}

--- a/web/dhcp_test.go
+++ b/web/dhcp_test.go
@@ -84,7 +84,7 @@ func testConfigDHCPPut(t *testing.T) {
 		t.Fatal("request failed with " + http.StatusText(resp.StatusCode))
 	}
 
-	conf, err := m.DHCP.GetConfig(context.Background())
+	conf, err := m.DHCP.GetConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func testConfigDHCPPut(t *testing.T) {
 		t.Fatal("request failed with " + http.StatusText(resp.StatusCode))
 	}
 
-	conf, err = m.DHCP.GetConfig(context.Background())
+	conf, err = m.DHCP.GetConfig()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/ipam.go
+++ b/web/ipam.go
@@ -22,12 +22,8 @@ func (s Server) handleConfigIPAM(w http.ResponseWriter, r *http.Request) {
 
 func (s Server) handleConfigIPAMGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	config, err := s.Model.IPAM.GetConfig(ctx)
+	config, err := s.Model.IPAM.GetConfig()
 	if err != nil {
-		renderError(ctx, w, InternalServerError(err))
-		return
-	}
-	if config == nil {
 		renderError(ctx, w, APIErrNotFound)
 		return
 	}

--- a/web/ipam_test.go
+++ b/web/ipam_test.go
@@ -94,7 +94,7 @@ func testConfigIPAMPut(t *testing.T) {
 		t.Fatal("request failed with " + http.StatusText(resp.StatusCode))
 	}
 
-	conf, err := m.IPAM.GetConfig(context.Background())
+	conf, err := m.IPAM.GetConfig()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
* retrieve the revision first of all, and use it as the start revision of watch.
* wait for driver to complete initialization before serving requests.
* watch for modification of configs and atomically update pointers to them.
* change API to return non-nil error if a config is nil.