### PR TITLE
Add BMC Type to Machine

### DIFF
--- a/cmd/sabactl/machines.go
+++ b/cmd/sabactl/machines.go
@@ -47,6 +47,7 @@ var machinesGetQuery = map[string]string{
 	"product":    "Product name (e.g. 'R630')",
 	"ipv4":       "IPv4 address",
 	"ipv6":       "IPv6 address",
+	"bmc-type":   "BMC type",
 }
 
 func (r *machinesGetCmd) SetFlags(f *flag.FlagSet) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -140,6 +140,7 @@ Field                        | Description
 `rack=<rack>`                | The rack number where the machine is in. If it is omitted, value set to `0`
 `role=<role>`                | The role of the machine(`boot` or `worker`)
 `product=<product>`          | The product name of the machine(e.g. `R630`)
+`bmc=<bmc>`                  | The BMC spec
 
 **Successful response**
 
@@ -164,7 +165,8 @@ $ curl -i -X POST \
   "product": "R630",
   "datacenter": "ty3",
   "rack": 1,
-  "role": "boot"
+  "role": "boot",
+  "bmc": {"type": "iDRAC-9"},
 }]' \
  'http://localhost:10080/api/v1/machines'
 ```
@@ -183,6 +185,7 @@ Query                      | Description
 `product=<product>`        | The product name of the machine(e.g. `R630`)
 `ipv4=<ip address>`        | IPv4 address
 `ipv6=<ip address>`        | IPv6 address
+`bmc-type=<bmc-type>`      | BMC type
 
 **Successful response**
 
@@ -198,11 +201,11 @@ Query                      | Description
 
 ```console
 $ curl -XGET 'localhost:10080/api/v1/machines?serial=1234abcd'
-[{"serial":"1234abcd","product":"R630","datacenter":"us","rack":1,"index-in-rack":1,"role":"boot","network":{"node0":{"ipv4":["10.69.0.197"],"ipv6":null},"node1":{"ipv4":["10.69.1.5"],"ipv6":null},"node2":{"ipv4":["10.69.1.69"],"ipv6":null}},"bmc":{"ipv4":["10.72.17.37"]}}]
+[{"serial":"1234abcd","product":"R630","datacenter":"us","rack":1,"index-in-rack":1,"role":"boot","network":{"node0":{"ipv4":["10.69.0.197"],"ipv6":null},"node1":{"ipv4":["10.69.1.5"],"ipv6":null},"node2":{"ipv4":["10.69.1.69"],"ipv6":null}},"bmc":{"type":"iDRAC-9","ipv4":["10.72.17.37"]}}]
 $ curl -XGET 'localhost:10080/api/v1/machines?datacenter=ty3&rack=1&product=R630'
-[{"serial":"10000000","product":"R630","datacenter":"ty3","rack":1,"index-in-rack":1,"role":"boot","network":{"node0":{"ipv4":["10.69.0.197"],"ipv6":null},"node1":{"ipv4":["10.69.1.5"],"ipv6":null},"node2":{"ipv4":["10.69.1.69"],"ipv6":null}},"bmc":{"ipv4":["10.72.17.37"]}},{"serial":"10000001","product":"R630","datacenter":"ty3","rack":1,"index-in-rack":1,"role":"boot","network":{"node0":{"ipv4":["10.69.0.197"],"ipv6":null},"node1":{"ipv4":["10.69.1.5"],"ipv6":null},"node2":{"ipv4":["10.69.1.69"],"ipv6":null}},"bmc":{"ipv4":["10.72.17.37"]}}]
+[{"serial":"10000000","product":"R630","datacenter":"ty3","rack":1,"index-in-rack":1,"role":"boot","network":{"node0":{"ipv4":["10.69.0.197"],"ipv6":null},"node1":{"ipv4":["10.69.1.5"],"ipv6":null},"node2":{"ipv4":["10.69.1.69"],"ipv6":null}},"bmc":{"type":"iDRAC-9","ipv4":["10.72.17.37"]}},{"serial":"10000001","product":"R630","datacenter":"ty3","rack":1,"index-in-rack":1,"role":"boot","network":{"node0":{"ipv4":["10.69.0.197"],"ipv6":null},"node1":{"ipv4":["10.69.1.5"],"ipv6":null},"node2":{"ipv4":["10.69.1.69"],"ipv6":null}},"bmc":{"type":"iDRAC-9","ipv4":["10.72.17.37"]}}]
 $ curl -XGET 'localhost:10080/api/v1/machines?ipv4=10.20.30.40'
-[{"serial":"20000000","product":"R630","datacenter":"us","rack":1,"index-in-rack":1,"role":"boot","network":{"node0":{"ipv4":["10.69.0.197"],"ipv6":null},"node1":{"ipv4":["10.20.30.40"],"ipv6":null},"node2":{"ipv4":["10.69.1.69"],"ipv6":null}},"bmc":{"ipv4":["10.72.17.37"]}}]
+[{"serial":"20000000","product":"R630","datacenter":"us","rack":1,"index-in-rack":1,"role":"boot","network":{"node0":{"ipv4":["10.69.0.197"],"ipv6":null},"node1":{"ipv4":["10.20.30.40"],"ipv6":null},"node2":{"ipv4":["10.69.1.69"],"ipv6":null}},"bmc":{"type":"iDRAC-9","ipv4":["10.72.17.37"]}}]
 ```
 
 ## <a name="deletemachines" />`DELETE /api/v1/machines/<serial>`

--- a/docs/sabactl.md
+++ b/docs/sabactl.md
@@ -73,7 +73,7 @@ Detailed specification of the input JSON file is same as that of the [`POST /api
 Show machines filtered by query parameters.
 
 ```console
-$ sabactl machines get [--serial <serial>] [--state <state>] [--datacenter <datacenter>] [--rack <rack>] [--product <product>] [--ipv4 <ip address>] [--ipv6 <ip address>]
+$ sabactl machines get [--serial <serial>] [--state <state>] [--datacenter <datacenter>] [--rack <rack>] [--product <product>] [--ipv4 <ip address>] [--ipv6 <ip address>] [--bmc-type <BMC type>]
 ```
 
 Detailed specification of the query parameters and the output JSON content is same as those of the [`GET /api/v1/machines` API](api.md#getmachines).

--- a/docs/sabactl.md
+++ b/docs/sabactl.md
@@ -62,8 +62,8 @@ Detailed specification of the input JSON file is same as that of the [`POST /api
 
 ```json
 [
-  { "serial": "<serial1>", "datacenter": "<datacenter1>", "rack": "<rack1>", "product": "<product1>", "role": "<role1>" },
-  { "serial": "<serial2>", "datacenter": "<datacenter2>", "rack": "<rack2>", "product": "<product2>", "role": "<role2>" }
+  { "serial": "<serial1>", "datacenter": "<datacenter1>", "rack": "<rack1>", "product": "<product1>", "role": "<role1>", "bmc": { "type": "iDRAC-9" }},
+  { "serial": "<serial2>", "datacenter": "<datacenter2>", "rack": "<rack2>", "product": "<product2>", "role": "<role2>", "bmc": { "type": "iDRAC-9" }}
 ]
 ```
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -41,6 +41,7 @@ $ etcdctl get /sabakan/machines/1234abcd --print-value-only | jq .
     }
   },
   "bmc": {
+    "type": "iDRAC-9",
     "ipv4": "10.72.17.37"
   }
 ```
@@ -53,7 +54,13 @@ Key              | Description
 `rack`           | Logical rack number (LRN) where the machine is in
 `index-in-rack`  | Index number of the machine in a rack; this does not correspond to physical position
 `network`        | IP addresses of the machine indexed with NIC names and protocol names (IPv4/IPv6)
-`bmc`            | IP addresses of the machine's BMC indexed with protocol names (IPv4/IPv6)
+`bmc`            | Machine's BMC specs; see below
+
+Key in `bmc`    | Description
+------------    | -----------
+`type`          | BMC type e.g. 'iDRAC-9', 'IPMI-2.0'
+`ipv4`          | IPv4 address of BMC
+`ipv6`          | IPv6 address of BMC
 
 `<prefix>/crypts/<serial>/<path>`
 ---------------------------------

--- a/e2e/sabactl_test.go
+++ b/e2e/sabactl_test.go
@@ -177,12 +177,18 @@ func testSabactlMachines(t *testing.T) {
 			Product:    "R730xd",
 			Datacenter: "ty3",
 			Role:       "worker",
+			BMC: sabakan.MachineBMC{
+				Type: sabakan.BmcIdrac9,
+			},
 		},
 		{
 			Serial:     "abcdefg",
 			Product:    "R730xd",
 			Datacenter: "ty3",
 			Role:       "boot",
+			BMC: sabakan.MachineBMC{
+				Type: sabakan.BmcIpmi2,
+			},
 		},
 	}
 	stdout, stderr, err = runSabactlWithFile(t, &machines, "machines", "create")

--- a/machines.go
+++ b/machines.go
@@ -1,8 +1,10 @@
 package sabakan
 
 const (
-	BMC_iDRAC_9 = "iDRAC-9"
-	BMC_IPMI_2  = "IPMI-2.0"
+	// BmcIdrac9 is BMC type for iDRAC-9
+	BmcIdrac9 = "iDRAC-9"
+	// BmcIpmi2 is BMC type for IPMI-2.0
+	BmcIpmi2 = "IPMI-2.0"
 )
 
 // Machine represents a server hardware.

--- a/machines.go
+++ b/machines.go
@@ -1,5 +1,10 @@
 package sabakan
 
+const (
+	BMC_iDRAC_9 = "iDRAC-9"
+	BMC_IPMI_2  = "IPMI-2.0"
+)
+
 // Machine represents a server hardware.
 type Machine struct {
 	Serial      string                    `json:"serial"`
@@ -40,4 +45,5 @@ func (n MachineNetwork) hasIPv6(ipv6 string) bool {
 type MachineBMC struct {
 	IPv4 string `json:"ipv4"`
 	IPv6 string `json:"ipv6"`
+	Type string `json:"type"`
 }

--- a/models/etcd/index.go
+++ b/models/etcd/index.go
@@ -20,6 +20,7 @@ type machinesIndex struct {
 	Role       map[string][]string
 	IPv4       map[string]string
 	IPv6       map[string]string
+	BMCType    map[string][]string
 }
 
 func newMachinesIndex() *machinesIndex {
@@ -30,6 +31,7 @@ func newMachinesIndex() *machinesIndex {
 		Role:       make(map[string][]string),
 		IPv4:       make(map[string]string),
 		IPv6:       make(map[string]string),
+		BMCType:    make(map[string][]string),
 	}
 }
 
@@ -73,6 +75,7 @@ func (mi *machinesIndex) addNoLock(m *sabakan.Machine) {
 	mcrack := fmt.Sprint(m.Rack)
 	mi.Rack[mcrack] = append(mi.Rack[mcrack], m.Serial)
 	mi.Role[m.Role] = append(mi.Role[m.Role], m.Serial)
+	mi.BMCType[m.BMC.Type] = append(mi.BMCType[m.BMC.Type], m.Serial)
 	for _, ifn := range m.Network {
 		for _, v := range ifn.IPv4 {
 			mi.IPv4[v] = m.Serial
@@ -114,6 +117,8 @@ func (mi *machinesIndex) deleteNoLock(m *sabakan.Machine) {
 	mi.Rack[mcrack] = append(mi.Rack[mcrack][:i], mi.Rack[mcrack][i+1:]...)
 	i = indexOf(mi.Role[m.Role], m.Serial)
 	mi.Role[m.Role] = append(mi.Role[m.Role][:i], mi.Role[m.Role][i+1:]...)
+	i = indexOf(mi.BMCType[m.BMC.Type], m.Serial)
+	mi.BMCType[m.BMC.Type] = append(mi.BMCType[m.BMC.Type][:i], mi.BMCType[m.BMC.Type][i+1:]...)
 	for _, ifn := range m.Network {
 		for _, v := range ifn.IPv4 {
 			delete(mi.IPv4, v)
@@ -161,6 +166,9 @@ func (mi *machinesIndex) query(q *sabakan.Query) []string {
 		if serial, ok := mi.IPv6[q.IPv6]; ok {
 			res[serial] = struct{}{}
 		}
+	}
+	for _, serial := range mi.BMCType[q.BMCType] {
+		res[serial] = struct{}{}
 	}
 
 	serials := make([]string, 0, len(res))

--- a/models/etcd/index_test.go
+++ b/models/etcd/index_test.go
@@ -11,9 +11,9 @@ func TestMachinesIndex(t *testing.T) {
 	mi := newMachinesIndex()
 
 	machines := []*sabakan.Machine{
-		{Serial: "1", Product: "R630", Datacenter: "ty3", Role: "boot", BMC: sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2}},
-		{Serial: "2", Product: "R630", Datacenter: "ty3", Role: "worker", BMC: sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2}},
-		{Serial: "3", Product: "R730xd", Datacenter: "ty3", Role: "worker", BMC: sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2}},
+		{Serial: "1", Product: "R630", Datacenter: "ty3", Role: "boot", BMC: sabakan.MachineBMC{Type: sabakan.BmcIpmi2}},
+		{Serial: "2", Product: "R630", Datacenter: "ty3", Role: "worker", BMC: sabakan.MachineBMC{Type: sabakan.BmcIpmi2}},
+		{Serial: "3", Product: "R730xd", Datacenter: "ty3", Role: "worker", BMC: sabakan.MachineBMC{Type: sabakan.BmcIpmi2}},
 	}
 
 	for _, m := range machines {
@@ -34,14 +34,14 @@ func TestMachinesIndex(t *testing.T) {
 			Product:    "R630",
 			Datacenter: "ty3",
 			Role:       "worker",
-			BMC:        sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2},
+			BMC:        sabakan.MachineBMC{Type: sabakan.BmcIpmi2},
 		},
 		&sabakan.Machine{
 			Serial:     "2",
 			Product:    "R730xd",
 			Datacenter: "ty3",
 			Role:       "worker",
-			BMC:        sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2},
+			BMC:        sabakan.MachineBMC{Type: sabakan.BmcIpmi2},
 		})
 
 	serials = mi.query(&sabakan.Query{Product: "R730xd"})
@@ -58,7 +58,7 @@ func TestMachinesIndex(t *testing.T) {
 		Product:    "R730xd",
 		Datacenter: "ty3",
 		Role:       "worker",
-		BMC:        sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2},
+		BMC:        sabakan.MachineBMC{Type: sabakan.BmcIpmi2},
 	})
 
 	serials = mi.query(&sabakan.Query{Product: "R730xd"})

--- a/models/etcd/index_test.go
+++ b/models/etcd/index_test.go
@@ -11,9 +11,9 @@ func TestMachinesIndex(t *testing.T) {
 	mi := newMachinesIndex()
 
 	machines := []*sabakan.Machine{
-		{Serial: "1", Product: "R630", Datacenter: "ty3", Role: "boot"},
-		{Serial: "2", Product: "R630", Datacenter: "ty3", Role: "worker"},
-		{Serial: "3", Product: "R730xd", Datacenter: "ty3", Role: "worker"},
+		{Serial: "1", Product: "R630", Datacenter: "ty3", Role: "boot", BMC: sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2}},
+		{Serial: "2", Product: "R630", Datacenter: "ty3", Role: "worker", BMC: sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2}},
+		{Serial: "3", Product: "R730xd", Datacenter: "ty3", Role: "worker", BMC: sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2}},
 	}
 
 	for _, m := range machines {
@@ -34,12 +34,14 @@ func TestMachinesIndex(t *testing.T) {
 			Product:    "R630",
 			Datacenter: "ty3",
 			Role:       "worker",
+			BMC:        sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2},
 		},
 		&sabakan.Machine{
 			Serial:     "2",
 			Product:    "R730xd",
 			Datacenter: "ty3",
 			Role:       "worker",
+			BMC:        sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2},
 		})
 
 	serials = mi.query(&sabakan.Query{Product: "R730xd"})
@@ -56,6 +58,7 @@ func TestMachinesIndex(t *testing.T) {
 		Product:    "R730xd",
 		Datacenter: "ty3",
 		Role:       "worker",
+		BMC:        sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2},
 	})
 
 	serials = mi.query(&sabakan.Query{Product: "R730xd"})

--- a/query.go
+++ b/query.go
@@ -11,6 +11,7 @@ type Query struct {
 	Role       string
 	IPv4       string
 	IPv6       string
+	BMCType    string
 }
 
 // Match returns true if all non-empty fields matches Machine
@@ -52,6 +53,9 @@ func (q *Query) Match(m *Machine) bool {
 		return false
 	}
 	if len(q.Role) > 0 && q.Role != m.Role {
+		return false
+	}
+	if len(q.BMCType) > 0 && q.BMCType != m.BMC.Type {
 		return false
 	}
 

--- a/web/machines.go
+++ b/web/machines.go
@@ -56,7 +56,7 @@ func (s Server) handleMachinesPost(w http.ResponseWriter, r *http.Request) {
 			renderError(r.Context(), w, BadRequest("BMC type is empty"))
 			return
 		}
-		if (m.BMC.Type != sabakan.BMC_IPMI_2) && (m.BMC.Type != sabakan.BMC_iDRAC_9) {
+		if (m.BMC.Type != sabakan.BmcIpmi2) && (m.BMC.Type != sabakan.BmcIdrac9) {
 			renderError(r.Context(), w, BadRequest("unknown BMC type"))
 			return
 		}

--- a/web/machines.go
+++ b/web/machines.go
@@ -52,6 +52,14 @@ func (s Server) handleMachinesPost(w http.ResponseWriter, r *http.Request) {
 			renderError(r.Context(), w, BadRequest("role is empty"))
 			return
 		}
+		if m.BMC.Type == "" {
+			renderError(r.Context(), w, BadRequest("BMC type is empty"))
+			return
+		}
+		if (m.BMC.Type != sabakan.BMC_IPMI_2) && (m.BMC.Type != sabakan.BMC_iDRAC_9) {
+			renderError(r.Context(), w, BadRequest("unknown BMC type"))
+			return
+		}
 	}
 
 	err = s.Model.Machine.Register(r.Context(), machines)
@@ -76,6 +84,7 @@ func getMachinesQuery(r *http.Request) *sabakan.Query {
 	q.Role = vals.Get("role")
 	q.IPv4 = vals.Get("ipv4")
 	q.IPv6 = vals.Get("ipv6")
+	q.BMCType = vals.Get("bmc-type")
 	return &q
 }
 

--- a/web/machines_test.go
+++ b/web/machines_test.go
@@ -29,30 +29,49 @@ func testMachinesPost(t *testing.T) {
   "product": "R630",
   "datacenter": "ty3",
   "rack": 1,
-  "role": "boot"
+  "role": "boot",
+  "bmc": {"type": "iDRAC-9"}
 }]`, http.StatusCreated},
 		{`[{
   "serial": "1234abcd",
   "product": "R630",
   "datacenter": "ty3",
   "rack": 1,
-  "role": "boot"
+  "role": "boot",
+  "bmc": {"type": "iDRAC-9"}
 }]`, http.StatusConflict},
 		{`[{
   "product": "R630",
   "datacenter": "ty3",
   "rack": 1,
-  "role": "boot"
+  "role": "boot",
+  "bmc": {"type": "iDRAC-9"}
 }]`, http.StatusBadRequest},
 		{`[{
   "serial": "5678abcd",
   "datacenter": "ty3",
   "rack": 1,
-  "role": "boot"
+  "role": "boot",
+  "bmc": {"type": "iDRAC-9"}
 }]`, http.StatusBadRequest},
 		{`[{
   "serial": "0000abcd",
   "product": "R630",
+  "rack": 1,
+  "role": "boot",
+  "bmc": {"type": "iDRAC-9"}
+}]`, http.StatusBadRequest},
+		{`[{
+  "serial": "2222abcd",
+  "product": "R630",
+  "datacenter": "ty3",
+  "rack": 1,
+  "bmc": {"type": "iDRAC-9"}
+}]`, http.StatusBadRequest},
+		{`[{
+  "serial": "2222abcd",
+  "product": "R630",
+  "datacenter": "ty3",
   "rack": 1,
   "role": "boot"
 }]`, http.StatusBadRequest},
@@ -60,7 +79,9 @@ func testMachinesPost(t *testing.T) {
   "serial": "2222abcd",
   "product": "R630",
   "datacenter": "ty3",
-  "rack": 1
+  "rack": 1,
+  "role": "boot",
+  "bmc": {"type": "unknown-BMC"}
 }]`, http.StatusBadRequest},
 	}
 
@@ -100,6 +121,7 @@ func testMachinesGet(t *testing.T) {
 			Datacenter: "ty3",
 			Rack:       1,
 			Role:       "boot",
+			BMC:        sabakan.MachineBMC{Type: sabakan.BMC_iDRAC_9},
 		},
 		{
 			Serial:     "5678abcd",
@@ -107,6 +129,7 @@ func testMachinesGet(t *testing.T) {
 			Datacenter: "ty3",
 			Rack:       1,
 			Role:       "worker",
+			BMC:        sabakan.MachineBMC{Type: sabakan.BMC_iDRAC_9},
 		},
 		{
 			Serial:     "1234efgh",
@@ -114,6 +137,7 @@ func testMachinesGet(t *testing.T) {
 			Datacenter: "ty3",
 			Rack:       2,
 			Role:       "boot",
+			BMC:        sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2},
 		},
 	})
 
@@ -147,11 +171,15 @@ func testMachinesGet(t *testing.T) {
 			status:   http.StatusOK,
 			expected: map[string]bool{"1234abcd": true, "1234efgh": true},
 		},
-
 		{
 			query:    map[string][]string{"serial": {"5689abcd"}},
 			status:   http.StatusNotFound,
 			expected: nil,
+		},
+		{
+			query:    map[string][]string{"bmc-type": {"iDRAC-9"}},
+			status:   http.StatusOK,
+			expected: map[string]bool{"1234abcd": true, "5678abcd": true},
 		},
 	}
 	for _, c := range cases {

--- a/web/machines_test.go
+++ b/web/machines_test.go
@@ -121,7 +121,7 @@ func testMachinesGet(t *testing.T) {
 			Datacenter: "ty3",
 			Rack:       1,
 			Role:       "boot",
-			BMC:        sabakan.MachineBMC{Type: sabakan.BMC_iDRAC_9},
+			BMC:        sabakan.MachineBMC{Type: sabakan.BmcIdrac9},
 		},
 		{
 			Serial:     "5678abcd",
@@ -129,7 +129,7 @@ func testMachinesGet(t *testing.T) {
 			Datacenter: "ty3",
 			Rack:       1,
 			Role:       "worker",
-			BMC:        sabakan.MachineBMC{Type: sabakan.BMC_iDRAC_9},
+			BMC:        sabakan.MachineBMC{Type: sabakan.BmcIdrac9},
 		},
 		{
 			Serial:     "1234efgh",
@@ -137,7 +137,7 @@ func testMachinesGet(t *testing.T) {
 			Datacenter: "ty3",
 			Rack:       2,
 			Role:       "boot",
-			BMC:        sabakan.MachineBMC{Type: sabakan.BMC_IPMI_2},
+			BMC:        sabakan.MachineBMC{Type: sabakan.BmcIpmi2},
 		},
 	})
 


### PR DESCRIPTION
- sabactl supports `--bmc-type` in `sabactl machines get`
- sabakan API supports `bmc-type` query parameter in GET`/api/v1/machines`
- BMC Type in the Machine is mandatory and supports `iDRAC-9` and `IPMI-2.0`.