### PR TITLE
[etcd] add username and password options

### DIFF
--- a/cmd/sabakan/config.go
+++ b/cmd/sabakan/config.go
@@ -30,6 +30,8 @@ type config struct {
 	EtcdServers  []string `yaml:"etcd-servers"`
 	EtcdPrefix   string   `yaml:"etcd-prefix"`
 	EtcdTimeout  string   `yaml:"etcd-timeout"`
+	EtcdUsername string   `yaml:"etcd-username"`
+	EtcdPassword string   `yaml:"etcd-password"`
 	DHCPBind     string   `yaml:"dhcp-bind"`
 	IPXEPath     string   `yaml:"ipxe-efi-path"`
 	ImageDir     string   `yaml:"image-dir"`

--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -29,10 +29,12 @@ type etcdConfig struct {
 }
 
 var (
-	flagHTTP        = flag.String("http", defaultListenHTTP, "<Listen IP>:<Port number>")
-	flagEtcdServers = flag.String("etcd-servers", strings.Join(defaultEtcdServers, ","), "comma-separated URLs of the backend etcd")
-	flagEtcdPrefix  = flag.String("etcd-prefix", defaultEtcdPrefix, "etcd prefix")
-	flagEtcdTimeout = flag.String("etcd-timeout", "2s", "dial timeout to etcd")
+	flagHTTP         = flag.String("http", defaultListenHTTP, "<Listen IP>:<Port number>")
+	flagEtcdServers  = flag.String("etcd-servers", strings.Join(defaultEtcdServers, ","), "comma-separated URLs of the backend etcd")
+	flagEtcdPrefix   = flag.String("etcd-prefix", defaultEtcdPrefix, "etcd prefix")
+	flagEtcdTimeout  = flag.String("etcd-timeout", "2s", "dial timeout to etcd")
+	flagEtcdUsername = flag.String("etcd-username", "", "username for etcd authentication")
+	flagEtcdPassword = flag.String("etcd-password", "", "password for etcd authentication")
 
 	flagDHCPBind     = flag.String("dhcp-bind", defaultDHCPBind, "bound ip addresses and port for dhcp server")
 	flagIPXEPath     = flag.String("ipxe-efi-path", defaultIPXEPath, "path to ipxe.efi")
@@ -55,6 +57,8 @@ func main() {
 		cfg.EtcdServers = strings.Split(*flagEtcdServers, ",")
 		cfg.EtcdPrefix = *flagEtcdPrefix
 		cfg.EtcdTimeout = *flagEtcdTimeout
+		cfg.EtcdUsername = *flagEtcdUsername
+		cfg.EtcdPassword = *flagEtcdPassword
 		cfg.DHCPBind = *flagDHCPBind
 		cfg.IPXEPath = *flagIPXEPath
 		cfg.ImageDir = *flagImageDir
@@ -96,6 +100,8 @@ func main() {
 	etcdCfg := clientv3.Config{
 		Endpoints:   e.Servers,
 		DialTimeout: timeout,
+		Username:    cfg.EtcdUsername,
+		Password:    cfg.EtcdPassword,
 	}
 	c, err := clientv3.New(etcdCfg)
 	if err != nil {

--- a/docs/sabakan.md
+++ b/docs/sabakan.md
@@ -13,12 +13,16 @@ Usage of /home/ymmt/go/bin/sabakan:
         path to configuration file
   -dhcp-bind string
         bound ip addresses and port for dhcp server (default "0.0.0.0:10067")
+  -etcd-password string
+        password for etcd authentication
   -etcd-prefix string
         etcd prefix (default "/sabakan")
   -etcd-servers string
         comma-separated URLs of the backend etcd (default "http://localhost:2379")
   -etcd-timeout string
         dial timeout to etcd (default "2s")
+  -etcd-username string
+        username for etcd authentication
   -http string
         <Listen IP>:<Port number> (default "0.0.0.0:10080")
   -image-dir string
@@ -41,6 +45,8 @@ Option          | Default value            | Description
 `etcd-prefix`   | `/sabakan`               | etcd prefix
 `etcd-servers`  | `http://localhost:2379`  | comma-separated URLs of the backend etcd
 `etcd-timeout`  | `2s`                     | dial timeout to etcd
+`etcd-username` | ""                       | username for etcd authentication
+`etcd-password` | ""                       | password for etcd authentication
 `http`          | `0.0.0.0:10080`          | Listen IP:Port number
 `image-dir`     | `/var/lib/sabakan`       | Directory to store boot images.
 `ipxe-efi-path` | `/usr/lib/ipxe/ipxe.efi` | path to ipxe.efi

--- a/models/etcd/watch.go
+++ b/models/etcd/watch.go
@@ -52,7 +52,7 @@ func (d *driver) initDHCPConfig(ctx context.Context) error {
 
 func (d *driver) startWatching(ctx context.Context, ch, indexCh chan<- struct{}) error {
 	// obtain the current revision to avoid missing events.
-	resp, err := d.client.Get(ctx, "/")
+	resp, err := d.client.Get(ctx, d.prefix+"/")
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func (d *driver) startWatching(ctx context.Context, ch, indexCh chan<- struct{})
 	// notify the caller of the readiness
 	ch <- struct{}{}
 
-	rch := d.client.Watch(ctx, d.prefix,
+	rch := d.client.Watch(ctx, d.prefix+"/",
 		clientv3.WithPrefix(),
 		clientv3.WithPrevKV(),
 		clientv3.WithRev(rev),


### PR DESCRIPTION
etcd can be protected by enabling user authentication.
To access such an instance, sabakan need to have configuration options for etcd authentication.

This commit adds these two:
* `etcd-username`: username for etcd auth.
* `etcd-password`: password for etcd auth.