### PR TITLE
Describe API access control

### DIFF
--- a/docs/sabakan.md
+++ b/docs/sabakan.md
@@ -38,7 +38,7 @@ Usage of /home/ymmt/go/bin/sabakan:
 Option          | Default value            | Description
 --------------- | ------------------------ | -----------
 `advertise-url` | ""                       | Public URL to access this server.  Required.
-`advertise-url` | "127.0.0.1"              | comma-separated IPs allowd to change resources
+`allow-ips`     | "127.0.0.1"              | comma-separated IPs allowd to change resources
 `config-file`   | ""                       | If given, configurations are read from the file.
 `dhcp-bind`     | `0.0.0.0:10067`          | bound ip addresses and port dhcp server
 `etcd-prefix`   | `/sabakan`               | etcd prefix


### PR DESCRIPTION
API access control denies APIs affecting the resources from remote
hosts.