### PR TITLE
Refactor on etcd client

### DIFF
--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -9,12 +9,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/namespace"
 	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/sabakan/dhcpd"
@@ -93,7 +93,7 @@ func main() {
 
 	var e etcdConfig
 	e.Servers = cfg.EtcdServers
-	e.Prefix = path.Clean("/" + cfg.EtcdPrefix)
+	e.Prefix = "/" + cfg.EtcdPrefix + "/"
 
 	timeout, err := time.ParseDuration(cfg.EtcdTimeout)
 	if err != nil {
@@ -110,6 +110,9 @@ func main() {
 	if err != nil {
 		log.ErrorExit(err)
 	}
+	c.KV = namespace.NewKV(c.KV, e.Prefix)
+	c.Watcher = namespace.NewWatcher(c.Watcher, e.Prefix)
+	c.Lease = namespace.NewLease(c.Lease, e.Prefix)
 	defer c.Close()
 
 	model := etcd.NewModel(c, cfg.ImageDir, advertiseURL)

--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -24,11 +24,6 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-type etcdConfig struct {
-	Servers []string
-	Prefix  string
-}
-
 var (
 	flagHTTP         = flag.String("http", defaultListenHTTP, "<Listen IP>:<Port number>")
 	flagEtcdServers  = flag.String("etcd-servers", strings.Join(defaultEtcdServers, ","), "comma-separated URLs of the backend etcd")
@@ -91,17 +86,13 @@ func main() {
 		log.ErrorExit(err)
 	}
 
-	var e etcdConfig
-	e.Servers = cfg.EtcdServers
-	e.Prefix = "/" + cfg.EtcdPrefix + "/"
-
 	timeout, err := time.ParseDuration(cfg.EtcdTimeout)
 	if err != nil {
 		log.ErrorExit(err)
 	}
 
 	etcdCfg := clientv3.Config{
-		Endpoints:   e.Servers,
+		Endpoints:   cfg.EtcdServers,
 		DialTimeout: timeout,
 		Username:    cfg.EtcdUsername,
 		Password:    cfg.EtcdPassword,
@@ -110,9 +101,9 @@ func main() {
 	if err != nil {
 		log.ErrorExit(err)
 	}
-	c.KV = namespace.NewKV(c.KV, e.Prefix)
-	c.Watcher = namespace.NewWatcher(c.Watcher, e.Prefix)
-	c.Lease = namespace.NewLease(c.Lease, e.Prefix)
+	c.KV = namespace.NewKV(c.KV, cfg.EtcdPrefix)
+	c.Watcher = namespace.NewWatcher(c.Watcher, cfg.EtcdPrefix)
+	c.Lease = namespace.NewLease(c.Lease, cfg.EtcdPrefix)
 	defer c.Close()
 
 	model := etcd.NewModel(c, cfg.ImageDir, advertiseURL)

--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -112,7 +112,7 @@ func main() {
 	}
 	defer c.Close()
 
-	model := etcd.NewModel(c, e.Prefix, cfg.ImageDir, advertiseURL)
+	model := etcd.NewModel(c, cfg.ImageDir, advertiseURL)
 	ch := make(chan struct{})
 	cmd.Go(func(ctx context.Context) error {
 		return model.Run(ctx, ch)

--- a/models/etcd/constants.go
+++ b/models/etcd/constants.go
@@ -2,14 +2,14 @@ package etcd
 
 // Internal schema keys.
 const (
-	KeyCrypts      = "/crypts"
-	KeyDHCP        = "/dhcp"
-	KeyIPAM        = "/ipam"
-	KeyLeaseUsages = "/lease-usages"
-	KeyMachines    = "/machines"
-	KeyNodeIndices = "/node-indices"
-	KeyImages      = "/images"
-	KeyIgnitions   = "/ignitions"
+	KeyCrypts      = "crypts/"
+	KeyDHCP        = "dhcp/"
+	KeyIPAM        = "ipam/"
+	KeyLeaseUsages = "lease-usages/"
+	KeyMachines    = "machines/"
+	KeyNodeIndices = "node-indices/"
+	KeyImages      = "images/"
+	KeyIgnitions   = "ignitions/"
 )
 
 // MaxDeleted is the maximum number of deleted image IDs stored in etcd.

--- a/models/etcd/dhcp.go
+++ b/models/etcd/dhcp.go
@@ -20,9 +20,7 @@ func (d *driver) putDHCPConfig(ctx context.Context, config *sabakan.DHCPConfig) 
 		return err
 	}
 
-	configKey := path.Join(d.prefix, KeyDHCP)
-
-	_, err = d.client.Put(ctx, configKey, string(j))
+	_, err = d.client.Put(ctx, KeyDHCP, string(j))
 	return err
 }
 
@@ -186,7 +184,7 @@ func generateDummyMAC(idx int) net.HardwareAddr {
 }
 
 func (d *driver) leaseUsageKey(lrkey string) string {
-	return path.Join(d.prefix, KeyLeaseUsages, lrkey)
+	return path.Join(KeyLeaseUsages, lrkey)
 }
 
 func (d *driver) initializeLeaseUsage(ctx context.Context, lrkey string) error {

--- a/models/etcd/dhcp_test.go
+++ b/models/etcd/dhcp_test.go
@@ -27,7 +27,7 @@ func testDHCPPutConfig(t *testing.T) {
 	}
 	<-ch
 
-	resp, err := d.client.Get(context.Background(), t.Name()+KeyDHCP)
+	resp, err := d.client.Get(context.Background(), KeyDHCP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func testDHCPGetConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = d.client.Put(context.Background(), t.Name()+KeyDHCP, string(bytes))
+	_, err = d.client.Put(context.Background(), KeyDHCP, string(bytes))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func testDHCPLease(t *testing.T) {
 		t.Error("dhcp lease should fail")
 	}
 
-	resp, err := d.client.Get(context.Background(), t.Name()+KeyLeaseUsages, clientv3.WithPrefix())
+	resp, err := d.client.Get(context.Background(), KeyLeaseUsages, clientv3.WithPrefix())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/models/etcd/driver.go
+++ b/models/etcd/driver.go
@@ -14,7 +14,6 @@ import (
 
 type driver struct {
 	client       *clientv3.Client
-	prefix       string
 	imageDir     string
 	advertiseURL *url.URL
 	mi           *machinesIndex
@@ -23,10 +22,9 @@ type driver struct {
 }
 
 // NewModel returns sabakan.Model
-func NewModel(client *clientv3.Client, prefix, imageDir string, advertiseURL *url.URL) sabakan.Model {
+func NewModel(client *clientv3.Client, imageDir string, advertiseURL *url.URL) sabakan.Model {
 	d := &driver{
 		client:       client,
-		prefix:       prefix,
 		imageDir:     imageDir,
 		advertiseURL: advertiseURL,
 		mi:           newMachinesIndex(),

--- a/models/etcd/ignition.go
+++ b/models/etcd/ignition.go
@@ -16,7 +16,7 @@ func (d *driver) PutTemplate(ctx context.Context, role string, template string) 
 RETRY:
 	now := time.Now()
 	id := strconv.FormatInt(now.UnixNano(), 10)
-	target := path.Join(d.prefix, KeyIgnitions, role, id)
+	target := path.Join(KeyIgnitions, role, id)
 
 	tresp, err := d.client.Txn(ctx).
 		// Prohibit overwriting
@@ -33,7 +33,7 @@ RETRY:
 		goto RETRY
 	}
 
-	prefix := path.Join(d.prefix, KeyIgnitions, role) + "/"
+	prefix := path.Join(KeyIgnitions, role) + "/"
 	resp, err := d.client.Get(ctx, prefix,
 		clientv3.WithPrefix(),
 		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
@@ -55,7 +55,7 @@ RETRY:
 
 // GetTemplateIDs implements sabakan.IgnitionModel
 func (d *driver) GetTemplateIDs(ctx context.Context, role string) ([]string, error) {
-	target := path.Join(d.prefix, KeyIgnitions, role) + "/"
+	target := path.Join(KeyIgnitions, role) + "/"
 	resp, err := d.client.Get(ctx, target,
 		clientv3.WithPrefix(),
 		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
@@ -79,7 +79,7 @@ func (d *driver) GetTemplateIDs(ctx context.Context, role string) ([]string, err
 
 // GetTemplate implements sabakan.IgnitionModel
 func (d *driver) GetTemplate(ctx context.Context, role string, id string) (string, error) {
-	target := path.Join(d.prefix, KeyIgnitions, role, id)
+	target := path.Join(KeyIgnitions, role, id)
 	resp, err := d.client.Get(ctx, target)
 	if err != nil {
 		return "", err
@@ -94,7 +94,7 @@ func (d *driver) GetTemplate(ctx context.Context, role string, id string) (strin
 
 // DeleteTemplate implements sabakan.IgnitionModel
 func (d *driver) DeleteTemplate(ctx context.Context, role string, id string) error {
-	target := path.Join(d.prefix, KeyIgnitions, role, id)
+	target := path.Join(KeyIgnitions, role, id)
 	resp, err := d.client.Delete(ctx, target)
 	if err != nil {
 		return err

--- a/models/etcd/image.go
+++ b/models/etcd/image.go
@@ -29,7 +29,7 @@ func (d *driver) getImageDir(os string) ImageDir {
 }
 
 func (d *driver) imageGetIndexWithRev(ctx context.Context, os string) (sabakan.ImageIndex, int64, error) {
-	key := path.Join(d.prefix, KeyImages, os)
+	key := path.Join(KeyImages, os)
 	resp, err := d.client.Get(ctx, key)
 	if err != nil {
 		return nil, 0, err
@@ -51,7 +51,7 @@ func (d *driver) imageGetIndexWithRev(ctx context.Context, os string) (sabakan.I
 }
 
 func (d *driver) imageGetDeletedWithRev(ctx context.Context, os string) ([]string, int64, error) {
-	key := path.Join(d.prefix, KeyImages, os, "deleted")
+	key := path.Join(KeyImages, os, "deleted")
 	resp, err := d.client.Get(ctx, key)
 	if err != nil {
 		return nil, 0, err
@@ -77,8 +77,8 @@ func (d *driver) imageCASIndex(ctx context.Context, os string,
 	index sabakan.ImageIndex, indexRev int64,
 	deleted []string, delRev int64) (*clientv3.TxnResponse, error) {
 
-	indexKey := path.Join(d.prefix, KeyImages, os)
-	deletedKey := path.Join(d.prefix, KeyImages, os, "deleted")
+	indexKey := path.Join(KeyImages, os)
+	deletedKey := path.Join(KeyImages, os, "deleted")
 
 	indexJSON, err := json.Marshal(index)
 	if err != nil {

--- a/models/etcd/image_test.go
+++ b/models/etcd/image_test.go
@@ -52,7 +52,7 @@ func testImagePutIndex(t *testing.T, d *driver, index sabakan.ImageIndex) {
 		t.Fatal(err)
 	}
 
-	key := path.Join(d.prefix, KeyImages, "coreos")
+	key := path.Join(KeyImages, "coreos")
 	_, err = d.client.Put(context.Background(), key, string(data))
 	if err != nil {
 		t.Fatal(err)

--- a/models/etcd/image_updater.go
+++ b/models/etcd/image_updater.go
@@ -50,7 +50,7 @@ RETRY:
 
 	img.URLs = append(img.URLs, d.myURL("/api/v1/images", os, id))
 
-	indexKey := path.Join(d.prefix, KeyImages, os)
+	indexKey := path.Join(KeyImages, os)
 	indexJSON, err := json.Marshal(index)
 	if err != nil {
 		return err
@@ -132,7 +132,7 @@ OUTER:
 }
 
 func (d *driver) updateImage(ctx context.Context, client *cmd.HTTPClient) error {
-	key := path.Join(d.prefix, KeyImages) + "/"
+	key := KeyImages + "/"
 	resp, err := d.client.Get(ctx, key, clientv3.WithPrefix())
 	if err != nil {
 		return err

--- a/models/etcd/image_updater.go
+++ b/models/etcd/image_updater.go
@@ -132,15 +132,14 @@ OUTER:
 }
 
 func (d *driver) updateImage(ctx context.Context, client *cmd.HTTPClient) error {
-	key := KeyImages + "/"
-	resp, err := d.client.Get(ctx, key, clientv3.WithPrefix())
+	resp, err := d.client.Get(ctx, KeyImages, clientv3.WithPrefix())
 	if err != nil {
 		return err
 	}
 
 	dataMap := make(map[string]updateData)
 	for _, kv := range resp.Kvs {
-		parts := strings.Split(string(kv.Key)[len(key):], "/")
+		parts := strings.Split(string(kv.Key)[len(KeyImages):], "/")
 		os := parts[0]
 
 		if len(parts) == 1 {

--- a/models/etcd/index.go
+++ b/models/etcd/index.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path"
 	"sync"
 
 	"github.com/coreos/etcd/clientv3"
@@ -35,9 +34,8 @@ func newMachinesIndex() *machinesIndex {
 	}
 }
 
-func (mi *machinesIndex) init(ctx context.Context, client *clientv3.Client, prefix string) error {
-	key := path.Join(prefix, KeyMachines)
-	resp, err := client.Get(ctx, key, clientv3.WithPrefix())
+func (mi *machinesIndex) init(ctx context.Context, client *clientv3.Client) error {
+	resp, err := client.Get(ctx, KeyMachines, clientv3.WithPrefix())
 	if err != nil {
 		return err
 	}

--- a/models/etcd/ipam.go
+++ b/models/etcd/ipam.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"path"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/clientv3util"
@@ -17,12 +16,9 @@ func (d *driver) putIPAMConfig(ctx context.Context, config *sabakan.IPAMConfig) 
 		return err
 	}
 
-	configKey := path.Join(d.prefix, KeyIPAM)
-	machinesKey := path.Join(d.prefix, KeyMachines)
-
 	tresp, err := d.client.Txn(ctx).
-		If(clientv3util.KeyMissing(machinesKey).WithPrefix()).
-		Then(clientv3.OpPut(configKey, string(j))).
+		If(clientv3util.KeyMissing(KeyMachines).WithPrefix()).
+		Then(clientv3.OpPut(KeyIPAM, string(j))).
 		Else().
 		Commit()
 	if err != nil {

--- a/models/etcd/ipam_test.go
+++ b/models/etcd/ipam_test.go
@@ -30,7 +30,7 @@ func testIPAMPutConfig(t *testing.T) {
 	}
 	<-ch
 
-	resp, err := d.client.Get(context.Background(), t.Name()+KeyIPAM)
+	resp, err := d.client.Get(context.Background(), KeyIPAM)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func testIPAMGetConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = d.client.Put(context.Background(), t.Name()+KeyIPAM, string(bytes))
+	_, err = d.client.Put(context.Background(), KeyIPAM, string(bytes))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/models/etcd/machine.go
+++ b/models/etcd/machine.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/clientv3util"
-	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/sabakan"
 )
@@ -34,7 +33,7 @@ RETRY:
 		log.Info("etcd: revision mismatch; retrying...", nil)
 		goto RETRY
 	}
-	if !tresp.Responses[0].Response.(*etcdserverpb.ResponseOp_ResponseTxn).ResponseTxn.Succeeded {
+	if !tresp.Responses[0].GetResponseTxn().Succeeded {
 		// inner If, i.e. conflictMachinesIfOps, evaluated to false
 		return sabakan.ErrConflicted
 	}
@@ -179,7 +178,7 @@ RETRY:
 		goto RETRY
 	}
 
-	if !resp.Responses[0].Response.(*etcdserverpb.ResponseOp_ResponseTxn).ResponseTxn.Succeeded {
+	if !resp.Responses[0].GetResponseTxn().Succeeded {
 		// KeyExists(machineKey) failed
 		return sabakan.ErrNotFound
 	}

--- a/models/etcd/machine.go
+++ b/models/etcd/machine.go
@@ -68,7 +68,7 @@ func (d *driver) doRegister(ctx context.Context, wmcs []*sabakan.Machine, usageM
 	usageCASIfOps := []clientv3.Cmp{}
 	txnThenOps := []clientv3.Op{}
 	for _, wmc := range wmcs {
-		key := path.Join(d.prefix, KeyMachines, wmc.Serial)
+		key := path.Join(KeyMachines, wmc.Serial)
 		conflictMachinesIfOps = append(conflictMachinesIfOps, clientv3util.KeyMissing(key))
 		j, err := json.Marshal(wmc)
 		if err != nil {
@@ -112,7 +112,7 @@ func (d *driver) Query(ctx context.Context, q *sabakan.Query) ([]*sabakan.Machin
 		log.Debug("etcd/machine: query serial", map[string]interface{}{
 			"serial": serial,
 		})
-		key := path.Join(d.prefix, KeyMachines, serial)
+		key := path.Join(KeyMachines, serial)
 		resp, err := d.client.Get(ctx, key)
 		if err != nil {
 			return nil, err
@@ -188,7 +188,7 @@ RETRY:
 }
 
 func (d *driver) doDelete(ctx context.Context, machine *sabakan.Machine, usage *rackIndexUsage) (*clientv3.TxnResponse, error) {
-	machineKey := path.Join(d.prefix, KeyMachines, machine.Serial)
+	machineKey := path.Join(KeyMachines, machine.Serial)
 	indexKey := d.indexInRackKey(machine.Rack)
 
 	j, err := json.Marshal(usage)

--- a/models/etcd/machine_test.go
+++ b/models/etcd/machine_test.go
@@ -35,7 +35,7 @@ func testRegister(t *testing.T) {
 	<-ch // wait for initialization of rack#0 node-indices
 	<-ch
 
-	resp, err := d.client.Get(context.Background(), KeyMachines+"/5678efgh")
+	resp, err := d.client.Get(context.Background(), KeyMachines+"5678efgh")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func testRegister(t *testing.T) {
 	}
 	<-ch
 
-	resp, err = d.client.Get(context.Background(), KeyMachines+"/00000000")
+	resp, err = d.client.Get(context.Background(), KeyMachines+"00000000")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func testDelete(t *testing.T) {
 	<-ch
 
 	// confirm deletion
-	resp, err := d.client.Get(context.Background(), KeyMachines+"/1234abcd")
+	resp, err := d.client.Get(context.Background(), KeyMachines+"1234abcd")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func testDelete(t *testing.T) {
 	}
 	<-ch
 
-	resp, err = d.client.Get(context.Background(), KeyMachines+"/1234abcd")
+	resp, err = d.client.Get(context.Background(), KeyMachines+"1234abcd")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/models/etcd/machine_test.go
+++ b/models/etcd/machine_test.go
@@ -35,7 +35,7 @@ func testRegister(t *testing.T) {
 	<-ch // wait for initialization of rack#0 node-indices
 	<-ch
 
-	resp, err := d.client.Get(context.Background(), t.Name()+KeyMachines+"/5678efgh")
+	resp, err := d.client.Get(context.Background(), KeyMachines+"/5678efgh")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func testRegister(t *testing.T) {
 	}
 	<-ch
 
-	resp, err = d.client.Get(context.Background(), t.Name()+KeyMachines+"/00000000")
+	resp, err = d.client.Get(context.Background(), KeyMachines+"/00000000")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func testDelete(t *testing.T) {
 	<-ch
 
 	// confirm deletion
-	resp, err := d.client.Get(context.Background(), t.Name()+KeyMachines+"/1234abcd")
+	resp, err := d.client.Get(context.Background(), KeyMachines+"/1234abcd")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func testDelete(t *testing.T) {
 	}
 	<-ch
 
-	resp, err = d.client.Get(context.Background(), t.Name()+KeyMachines+"/1234abcd")
+	resp, err = d.client.Get(context.Background(), KeyMachines+"/1234abcd")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/models/etcd/main_test.go
+++ b/models/etcd/main_test.go
@@ -79,7 +79,7 @@ func newEtcdClient(prefix string) (*clientv3.Client, error) {
 }
 
 func testNewDriver(t *testing.T) (*driver, <-chan struct{}) {
-	client, err := newEtcdClient(t.Name())
+	client, err := newEtcdClient(t.Name() + "/")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/models/etcd/node_index.go
+++ b/models/etcd/node_index.go
@@ -85,7 +85,7 @@ func (r *rackIndexUsage) release(m *sabakan.Machine) (needUpdate bool) {
 }
 
 func (d *driver) indexInRackKey(rack uint) string {
-	return path.Join(d.prefix, KeyNodeIndices, fmt.Sprint(rack))
+	return path.Join(KeyNodeIndices, fmt.Sprint(rack))
 }
 
 func (d *driver) initializeNodeIndices(ctx context.Context, rack uint) error {

--- a/models/etcd/storage.go
+++ b/models/etcd/storage.go
@@ -11,7 +11,7 @@ import (
 
 // GetEncryptionKey implements sabakan.StorageModel
 func (d *driver) GetEncryptionKey(ctx context.Context, serial string, diskByPath string) ([]byte, error) {
-	target := path.Join(d.prefix, KeyCrypts, serial, diskByPath)
+	target := path.Join(KeyCrypts, serial, diskByPath)
 	resp, err := d.client.Get(ctx, target)
 	if err != nil {
 		return nil, err
@@ -26,7 +26,7 @@ func (d *driver) GetEncryptionKey(ctx context.Context, serial string, diskByPath
 
 // PutEncryptionKey implements sabakan.StorageModel
 func (d *driver) PutEncryptionKey(ctx context.Context, serial string, diskByPath string, key []byte) error {
-	target := path.Join(d.prefix, KeyCrypts, serial, diskByPath)
+	target := path.Join(KeyCrypts, serial, diskByPath)
 
 	tresp, err := d.client.Txn(ctx).
 		// Prohibit overwriting
@@ -47,7 +47,7 @@ func (d *driver) PutEncryptionKey(ctx context.Context, serial string, diskByPath
 
 // DeleteEncryptionKeys implements sabakan.StorageModel
 func (d *driver) DeleteEncryptionKeys(ctx context.Context, serial string) ([]string, error) {
-	target := path.Join(d.prefix, KeyCrypts, serial) + "/"
+	target := path.Join(KeyCrypts, serial) + "/"
 
 	dresp, err := d.client.Delete(ctx, target, clientv3.WithPrefix(), clientv3.WithPrevKV())
 	if err != nil {

--- a/models/etcd/watch.go
+++ b/models/etcd/watch.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	"context"
 	"encoding/json"
-	"path"
 	"strings"
 
 	"github.com/coreos/etcd/clientv3"
@@ -11,8 +10,7 @@ import (
 )
 
 func (d *driver) initIPAMConfig(ctx context.Context) error {
-	ipamKey := path.Join(d.prefix, KeyIPAM)
-	resp, err := d.client.Get(ctx, ipamKey)
+	resp, err := d.client.Get(ctx, KeyIPAM)
 	if err != nil {
 		return err
 	}
@@ -31,8 +29,7 @@ func (d *driver) initIPAMConfig(ctx context.Context) error {
 }
 
 func (d *driver) initDHCPConfig(ctx context.Context) error {
-	dhcpKey := path.Join(d.prefix, KeyDHCP)
-	resp, err := d.client.Get(ctx, dhcpKey)
+	resp, err := d.client.Get(ctx, KeyDHCP)
 	if err != nil {
 		return err
 	}
@@ -52,7 +49,7 @@ func (d *driver) initDHCPConfig(ctx context.Context) error {
 
 func (d *driver) startWatching(ctx context.Context, ch, indexCh chan<- struct{}) error {
 	// obtain the current revision to avoid missing events.
-	resp, err := d.client.Get(ctx, d.prefix+"/")
+	resp, err := d.client.Get(ctx, "/")
 	if err != nil {
 		return err
 	}
@@ -68,7 +65,7 @@ func (d *driver) startWatching(ctx context.Context, ch, indexCh chan<- struct{})
 		return err
 	}
 
-	err = d.mi.init(ctx, d.client, d.prefix)
+	err = d.mi.init(ctx, d.client)
 	if err != nil {
 		return err
 	}
@@ -76,7 +73,7 @@ func (d *driver) startWatching(ctx context.Context, ch, indexCh chan<- struct{})
 	// notify the caller of the readiness
 	ch <- struct{}{}
 
-	rch := d.client.Watch(ctx, d.prefix+"/",
+	rch := d.client.Watch(ctx, "/",
 		clientv3.WithPrefix(),
 		clientv3.WithPrevKV(),
 		clientv3.WithRev(rev),
@@ -84,7 +81,7 @@ func (d *driver) startWatching(ctx context.Context, ch, indexCh chan<- struct{})
 	for wresp := range rch {
 		for _, ev := range wresp.Events {
 			var err error
-			key := string(ev.Kv.Key[len(d.prefix):])
+			key := string(ev.Kv.Key)
 			switch {
 			case strings.HasPrefix(key, KeyMachines):
 				err = d.handleMachines(ev)

--- a/models/etcd/watch.go
+++ b/models/etcd/watch.go
@@ -73,7 +73,7 @@ func (d *driver) startWatching(ctx context.Context, ch, indexCh chan<- struct{})
 	// notify the caller of the readiness
 	ch <- struct{}{}
 
-	rch := d.client.Watch(ctx, "/",
+	rch := d.client.Watch(ctx, "",
 		clientv3.WithPrefix(),
 		clientv3.WithPrevKV(),
 		clientv3.WithRev(rev),


### PR DESCRIPTION
This Pull Req. contains the following refactors:
- Using etcd [namespace](https://godoc.org/github.com/coreos/etcd/clientv3/namespace) instead of `prefix` variable
- Using GetResponseTxn instead of internal protobuf.