### PR TITLE
fix sabakan prefix

### DIFF
--- a/cmd/sabakan/config.go
+++ b/cmd/sabakan/config.go
@@ -2,7 +2,7 @@ package main
 
 const (
 	defaultListenHTTP  = "0.0.0.0:10080"
-	defaultEtcdPrefix  = "/sabakan"
+	defaultEtcdPrefix  = "/sabakan/"
 	defaultEtcdTimeout = "2s"
 	defaultDHCPBind    = "0.0.0.0:10067"
 	defaultIPXEPath    = "/usr/lib/ipxe/ipxe.efi"

--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -111,6 +111,11 @@ func main() {
 	cmd.Go(func(ctx context.Context) error {
 		return model.Run(ctx, ch)
 	})
+	cmd.Go(func(ctx context.Context) error {
+		<-ctx.Done()
+		ch <- struct{}{}
+		return nil
+	})
 	// waiting the driver gets ready
 	<-ch
 


### PR DESCRIPTION
* sabakan's etcd prefix should have `/` at the end.
* When connecting to etcd failed, sabakan should be terminated with an error.