### PR TITLE
Asset management

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Planned features
 
     Sabakan provides API to change server status for life-cycle management.
 
+* Asset management
+
+    In order to help initialization of client servers, sabakan can work
+    as a file server from which clients can download assets via HTTP.
+
 * Logs
 
     To track problems and life-cycle events, sabakan keeps operation logs

--- a/asset.go
+++ b/asset.go
@@ -10,13 +10,11 @@ type Asset struct {
 	Date        time.Time `json:"date"`
 	Sha256      string    `json:"sha256"`
 	URLs        []string  `json:"urls"`
-	Version     int64     `json:"version"`
 	Exists      bool      `json:"exists"`
 }
 
 // AssetStatus is the status of an asset.
 type AssetStatus struct {
-	Status  int   `json:"status"`
-	Version int64 `json:"version"`
-	ID      int   `json:"id,string"`
+	Status int `json:"status"`
+	ID     int `json:"id,string"`
 }

--- a/asset.go
+++ b/asset.go
@@ -1,0 +1,22 @@
+package sabakan
+
+import "time"
+
+// Asset represents an asset.
+type Asset struct {
+	Name        string    `json:"name"`
+	ID          int       `json:"id,string"`
+	ContentType string    `json:"content-type"`
+	Date        time.Time `json:"date"`
+	Sha256      string    `json:"sha256"`
+	URLs        []string  `json:"urls"`
+	Version     int64     `json:"version"`
+	Exists      bool      `json:"exists"`
+}
+
+// AssetStatus is the status of an asset.
+type AssetStatus struct {
+	Status  int   `json:"status"`
+	Version int64 `json:"version"`
+	ID      int   `json:"id,string"`
+}

--- a/client/assets.go
+++ b/client/assets.go
@@ -79,6 +79,7 @@ func AssetsUpload(ctx context.Context, name, filename string) (*sabakan.AssetSta
 
 	req.ContentLength = size
 	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Expect", "100-continue")
 
 	res, err := client.http.Do(req)
 	if err != nil {

--- a/client/assets.go
+++ b/client/assets.go
@@ -1,0 +1,106 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path"
+
+	"github.com/cybozu-go/sabakan"
+)
+
+// AssetsIndex retrieves index of assets
+func AssetsIndex(ctx context.Context) ([]string, *Status) {
+	var index []string
+	err := client.getJSON(ctx, "/assets", nil, &index)
+	if err != nil {
+		return nil, err
+	}
+	return index, nil
+}
+
+// AssetsInfo retrieves meta data of an asset
+func AssetsInfo(ctx context.Context, name string) (*sabakan.Asset, *Status) {
+	var asset sabakan.Asset
+	err := client.getJSON(ctx, path.Join("/assets", name, "meta"), nil, &asset)
+	if err != nil {
+		return nil, err
+	}
+	return &asset, nil
+}
+
+func detectContentTypeFromFile(file *os.File) (string, error) {
+	// from filename extension; this may return ""
+	contentType := mime.TypeByExtension(path.Ext(file.Name()))
+	if len(contentType) != 0 {
+		return contentType, nil
+	}
+
+	// from first 512 bytes; this returns "application/octec-stream" as fallback
+	buf := make([]byte, 512)
+	_, err := file.Read(buf)
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	_, err = file.Seek(0, 0)
+	if err != nil {
+		return "", err
+	}
+	return http.DetectContentType(buf), nil
+}
+
+// AssetsUpload stores a file as an asset
+func AssetsUpload(ctx context.Context, name, filename string) (*sabakan.AssetStatus, *Status) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, ErrorStatus(err)
+	}
+	defer file.Close()
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return nil, ErrorStatus(err)
+	}
+	size := fileInfo.Size()
+
+	contentType, err := detectContentTypeFromFile(file)
+	if err != nil {
+		return nil, ErrorStatus(err)
+	}
+
+	req, err := http.NewRequest("PUT", client.endpoint+path.Join("/api/v1/assets", name), file)
+	if err != nil {
+		return nil, ErrorStatus(err)
+	}
+	req = req.WithContext(ctx)
+
+	req.ContentLength = size
+	req.Header.Set("Content-Type", contentType)
+
+	res, err := client.http.Do(req)
+	if err != nil {
+		return nil, ErrorStatus(err)
+	}
+	defer res.Body.Close()
+
+	errorStatus := ErrorHTTPStatus(res)
+	if errorStatus != nil {
+		return nil, errorStatus
+	}
+
+	var status sabakan.AssetStatus
+	err = json.NewDecoder(res.Body).Decode(&status)
+	if err != nil {
+		return nil, ErrorStatus(err)
+	}
+
+	return &status, nil
+}
+
+// AssetsDelete deletes an asset
+func AssetsDelete(ctx context.Context, name string) *Status {
+	return client.sendRequest(ctx, "DELETE", path.Join("/assets", name))
+}

--- a/cmd/sabactl/assets.go
+++ b/cmd/sabactl/assets.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"os"
+
+	"github.com/cybozu-go/sabakan/client"
+	"github.com/google/subcommands"
+)
+
+type assetsCmd struct{}
+
+func (c assetsCmd) SetFlags(f *flag.FlagSet) {}
+
+func (c assetsCmd) Execute(ctx context.Context, f *flag.FlagSet) subcommands.ExitStatus {
+	cmdr := newCommander(f, "assets")
+	cmdr.Register(assetsIndexCommand(), "")
+	cmdr.Register(assetsInfoCommand(), "")
+	cmdr.Register(assetsUploadCommand(), "")
+	cmdr.Register(assetsDeleteCommand(), "")
+	return cmdr.Execute(ctx)
+}
+
+func assetsCommand() subcommands.Command {
+	return subcmd{
+		assetsCmd{},
+		"assets",
+		"manage assets",
+		"assets ACTION ...",
+	}
+}
+
+type assetsIndexCmd struct{}
+
+func (c assetsIndexCmd) SetFlags(f *flag.FlagSet) {}
+
+func (c assetsIndexCmd) Execute(ctx context.Context, f *flag.FlagSet) subcommands.ExitStatus {
+	if f.NArg() != 0 {
+		f.Usage()
+		return client.ExitUsageError
+	}
+
+	index, errStatus := client.AssetsIndex(ctx)
+	if errStatus != nil {
+		return handleError(errStatus)
+	}
+
+	e := json.NewEncoder(os.Stdout)
+	e.SetIndent("", "  ")
+	err := e.Encode(index)
+	return handleError(err)
+}
+
+func assetsIndexCommand() subcommands.Command {
+	return subcmd{
+		assetsIndexCmd{},
+		"index",
+		"get index of assets",
+		"index",
+	}
+}
+
+type assetsInfoCmd struct{}
+
+func (c assetsInfoCmd) SetFlags(f *flag.FlagSet) {}
+
+func (c assetsInfoCmd) Execute(ctx context.Context, f *flag.FlagSet) subcommands.ExitStatus {
+	if f.NArg() != 1 {
+		f.Usage()
+		return client.ExitUsageError
+	}
+
+	asset, errStatus := client.AssetsInfo(ctx, f.Arg(0))
+	if errStatus != nil {
+		return handleError(errStatus)
+	}
+
+	e := json.NewEncoder(os.Stdout)
+	e.SetIndent("", "  ")
+	err := e.Encode(asset)
+	return handleError(err)
+}
+
+func assetsInfoCommand() subcommands.Command {
+	return subcmd{
+		assetsInfoCmd{},
+		"info",
+		"get meta data of asset",
+		"info NAME",
+	}
+}
+
+type assetsUploadCmd struct{}
+
+func (c assetsUploadCmd) SetFlags(f *flag.FlagSet) {}
+
+func (c assetsUploadCmd) Execute(ctx context.Context, f *flag.FlagSet) subcommands.ExitStatus {
+	if f.NArg() != 2 {
+		f.Usage()
+		return client.ExitUsageError
+	}
+
+	status, errStatus := client.AssetsUpload(ctx, f.Arg(0), f.Arg(1))
+	if errStatus != nil {
+		return handleError(errStatus)
+	}
+
+	e := json.NewEncoder(os.Stdout)
+	e.SetIndent("", "  ")
+	err := e.Encode(status)
+	return handleError(err)
+}
+
+func assetsUploadCommand() subcommands.Command {
+	return subcmd{
+		assetsUploadCmd{},
+		"upload",
+		"upload asset",
+		"upload NAME FILE",
+	}
+}
+
+type assetsDeleteCmd struct{}
+
+func (c assetsDeleteCmd) SetFlags(f *flag.FlagSet) {}
+
+func (c assetsDeleteCmd) Execute(ctx context.Context, f *flag.FlagSet) subcommands.ExitStatus {
+	if f.NArg() != 1 {
+		f.Usage()
+		return client.ExitUsageError
+	}
+
+	errStatus := client.AssetsDelete(ctx, f.Arg(0))
+	return handleError(errStatus)
+}
+
+func assetsDeleteCommand() subcommands.Command {
+	return subcmd{
+		assetsDeleteCmd{},
+		"delete",
+		"delete asset",
+		"delete NAME",
+	}
+}

--- a/cmd/sabactl/main.go
+++ b/cmd/sabactl/main.go
@@ -24,6 +24,7 @@ func main() {
 	subcommands.Register(ipamCommand(), "")
 	subcommands.Register(machinesCommand(), "")
 	subcommands.Register(imagesCommand(), "")
+	subcommands.Register(assetsCommand(), "")
 	subcommands.Register(ignitionsCommand(), "")
 	flag.Parse()
 	cmd.LogConfig{}.Apply()

--- a/cmd/sabakan/config.go
+++ b/cmd/sabakan/config.go
@@ -6,7 +6,7 @@ const (
 	defaultEtcdTimeout = "2s"
 	defaultDHCPBind    = "0.0.0.0:10067"
 	defaultIPXEPath    = "/usr/lib/ipxe/ipxe.efi"
-	defaultImageDir    = "/var/lib/sabakan"
+	defaultDataDir     = "/var/lib/sabakan"
 )
 
 var (
@@ -22,7 +22,7 @@ func newConfig() *config {
 		EtcdTimeout: defaultEtcdTimeout,
 		DHCPBind:    defaultDHCPBind,
 		IPXEPath:    defaultIPXEPath,
-		ImageDir:    defaultImageDir,
+		DataDir:     defaultDataDir,
 		AllowIPs:    defaultAllowIPs,
 	}
 }
@@ -36,7 +36,7 @@ type config struct {
 	EtcdPassword string   `yaml:"etcd-password"`
 	DHCPBind     string   `yaml:"dhcp-bind"`
 	IPXEPath     string   `yaml:"ipxe-efi-path"`
-	ImageDir     string   `yaml:"image-dir"`
+	DataDir      string   `yaml:"data-dir"`
 	AdvertiseURL string   `yaml:"advertise-url"`
 	AllowIPs     []string `yaml:"allow-ips"`
 }

--- a/cmd/sabakan/main.go
+++ b/cmd/sabakan/main.go
@@ -34,7 +34,7 @@ var (
 
 	flagDHCPBind     = flag.String("dhcp-bind", defaultDHCPBind, "bound ip addresses and port for dhcp server")
 	flagIPXEPath     = flag.String("ipxe-efi-path", defaultIPXEPath, "path to ipxe.efi")
-	flagImageDir     = flag.String("image-dir", defaultImageDir, "directory to store boot images")
+	flagDataDir      = flag.String("data-dir", defaultDataDir, "directory to store files")
 	flagAdvertiseURL = flag.String("advertise-url", "", "public URL of this server")
 	flagAllowIPs     = flag.String("allow-ips", strings.Join(defaultAllowIPs, ","), "comma-separated IPs allowed to change resources")
 
@@ -58,7 +58,7 @@ func main() {
 		cfg.EtcdPassword = *flagEtcdPassword
 		cfg.DHCPBind = *flagDHCPBind
 		cfg.IPXEPath = *flagIPXEPath
-		cfg.ImageDir = *flagImageDir
+		cfg.DataDir = *flagDataDir
 		cfg.AdvertiseURL = *flagAdvertiseURL
 		cfg.AllowIPs = strings.Split(*flagAllowIPs, ",")
 	} else {
@@ -73,8 +73,8 @@ func main() {
 		f.Close()
 	}
 
-	if !filepath.IsAbs(cfg.ImageDir) {
-		fmt.Fprintln(os.Stderr, "image-dir must be an absolute path")
+	if !filepath.IsAbs(cfg.DataDir) {
+		fmt.Fprintln(os.Stderr, "data-dir must be an absolute path")
 		os.Exit(1)
 	}
 	if cfg.AdvertiseURL == "" {
@@ -106,7 +106,7 @@ func main() {
 	c.Lease = namespace.NewLease(c.Lease, cfg.EtcdPrefix)
 	defer c.Close()
 
-	model := etcd.NewModel(c, cfg.ImageDir, advertiseURL)
+	model := etcd.NewModel(c, cfg.DataDir, advertiseURL)
 	ch := make(chan struct{})
 	cmd.Go(func(ctx context.Context) error {
 		return model.Run(ctx, ch)

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,11 @@ REST API
 * [PUT /api/v1/images/coreos/ID](#putimages)
 * [GET /api/v1/images/coreos/ID](#getimages)
 * [DELETE /api/v1/images/coreos/ID](#deleteimages)
+* [GET /api/v1/assets](#getassetsindex)
+* [PUT /api/v1/assets/NAME](#putassets)
+* [GET|HEAD /api/v1/assets/NAME](#getassets)
+* [GET /api/v1/assets/NAME/meta](#getassetsmeta)
+* [DELETE /api/v1/assets/NAME](#deleteassets)
 * [GET /api/v1/boot/ipxe.efi](#getipxe)
 * [GET /api/v1/boot/coreos/ipxe](#getcoreosipxe)
 * [GET /api/v1/boot/coreos/ipxe/SERIAL](#getcoreosipxeserial)
@@ -310,6 +315,99 @@ Remove the image specified by `<id>` from the index.
 - No image has the ID.
 
   HTTP status code: 404 Not found
+
+## <a name="getassetsindex" />`GET /api/v1/assets`
+
+Get the list of asset names as JSON array.
+
+## <a name="putassets" />`PUT /api/v1/assets/<NAME>`
+
+Upload a file as an asset.  Content-type and content-length headers must be
+supplied by requests.
+
+**Successful response**
+
+- HTTP status code: 201 Created, or 200 OK
+- HTTP response header: `application/json`
+- HTTP response body: JSON
+
+The response for a newly created asset looks like:
+```json
+{
+    "status": 201,
+    "version": 1,
+    "id": 15,
+}
+```
+
+The response for an updated asset looks like:
+```json
+{
+    "status": 200,
+    "version": 3,
+    "id": 19,
+}
+```
+
+**Failure responses**
+
+- No content-type request header:
+
+    HTTP status code: 400 Bad Request
+
+- No content-length request header:
+
+    HTTP status code: 411 Length Required
+
+- Content is too large:
+
+    HTTP status code: 413 Payload Too Large
+
+## <a name="getassets" />`GET /api/v1/assets/<NAME>`
+
+Download the named asset.
+
+**Successful response**
+
+- HTTP status code: 200 OK
+
+**Failure responses**
+
+- The asset was not found.
+
+    HTTP status code: 404 Not found
+
+## <a name="getassetsmeta" />`GET /api/v1/assets/<NAME>/meta`
+
+Fetch the meta data of the named asset.
+
+**Successful response**
+
+- HTTP status code: 200 OK
+- HTTP response header: `application/json`
+
+The response JSON is described in [asset management](assets.md).
+
+**Failure responses**
+
+- The asset was not found.
+
+    HTTP status code: 404 Not found
+
+## <a name="deleteassets" />`DELETE /api/v1/assets/<NAME>`
+
+Remove the named asset.
+
+**Successful response**
+
+- HTTP status code: 200 OK
+- HTTP response body: empty
+
+**Failure responses**
+
+- The asset was not found.
+
+    HTTP status code: 404 Not found
 
 ## <a name="getipxe" />`GET /api/v1/boot/ipxe.efi`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -336,7 +336,7 @@ The response for a newly created asset looks like:
 {
     "status": 201,
     "version": 1,
-    "id": 15,
+    "id": "15"
 }
 ```
 
@@ -345,7 +345,7 @@ The response for an updated asset looks like:
 {
     "status": 200,
     "version": 3,
-    "id": 19,
+    "id": "19"
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -335,7 +335,6 @@ The response for a newly created asset looks like:
 ```json
 {
     "status": 201,
-    "version": 1,
     "id": "15"
 }
 ```
@@ -344,7 +343,6 @@ The response for an updated asset looks like:
 ```json
 {
     "status": 200,
-    "version": 3,
     "id": "19"
 }
 ```
@@ -354,6 +352,10 @@ The response for an updated asset looks like:
 - No content-type request header:
 
     HTTP status code: 400 Bad Request
+
+- Upload conflicted:
+
+    HTTP status code: 409 Conflicted
 
 - No content-length request header:
 
@@ -369,7 +371,13 @@ Download the named asset.
 
 **Successful response**
 
-- HTTP status code: 200 OK
+HTTP status code:
+- 200 OK
+
+Response headers:
+
+- `X-Sabakan-Asset-ID`: ID of the asset
+- `X-Sabakan-Asset-SHA256`: SHA256 checksum of the asset
 
 **Failure responses**
 
@@ -383,8 +391,11 @@ Fetch the meta data of the named asset.
 
 **Successful response**
 
-- HTTP status code: 200 OK
-- HTTP response header: `application/json`
+HTTP status code:
+- 200 OK
+
+HTTP response header:
+- `Content-Type`: `application/json`
 
 The response JSON is described in [asset management](assets.md).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -322,8 +322,13 @@ Get the list of asset names as JSON array.
 
 ## <a name="putassets" />`PUT /api/v1/assets/<NAME>`
 
-Upload a file as an asset.  Content-type and content-length headers must be
-supplied by requests.
+Upload a file as an asset.
+
+**Request headers**
+
+- `Content-Type`: required
+- `Content-Length`: required
+- `X-Sabakan-Asset-SHA256`: if given, the uploaded data will be verified by SHA256.
 
 **Successful response**
 

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -1,0 +1,82 @@
+Asset management
+================
+
+In order to help initialization of client servers, sabakan can work
+as a file server from which clients can download assets via HTTP.
+
+How it works
+------------
+
+### Meta data
+
+Meta data of assets are stored in etcd as follows:
+
+* Each asset has a key like `<prefix>/assets/<NAME>`.
+* The value of the key is a JSON like this:
+
+```json
+{
+    "name": "hoge.tar.gz",
+    "id": "15",
+    "content-type": "application/tar",
+    "date": "2017-12-02T15:04:05Z",
+    "sha256": "2e0390eb024a52963db7b95e84a9c2b12c004054a7bad9a97ec0c7c89d4681d2",
+    "urls": [
+        "http://10.1.2.3:10080/api/v1/assets/hoge.tar.gz",
+        "http://10.98.76.54:10080/api/v1/assets/hoge.tar.gz"
+    ],
+    "version": 1,
+    "exists": true
+}
+```
+
+`id` is a unique numerical ID assigned by sabakan.  Each time a key is
+updated, a new `id` will be assigned.
+
+`urls` is a list of URLs where the asset can be downloaded.
+Details are described in the next section.
+
+`version` is only meaningful when this JSON is returned from a REST API.
+It indicates how many times the key was updated.  Internally, it is [the
+version of the key](https://coreos.com/etcd/docs/latest/learning/api.html#key-value-pair).
+
+`exists` is only meaningful when this JSON is returned from a REST API.
+It becomes `true` if the server has a local copy of the asset.
+
+### Assets directory
+
+Sabakan saves uploaded assets under `/var/lib/sabakan/assets` directory.
+
+Assets are stored as a file whose name is a numeric ID assigned by sabakan:
+
+```
+/var/lib/sabakan/assets/
+    - 3
+    - 9
+    - 15
+    - 29
+    - ...
+```
+### Finding and pulling new assets
+
+At first, an asset exists only in the server who received the asset via REST API.
+Other sabakan servers need to pull the asset from the first server.
+
+To distribute the new asset, the first server adds meta data to etcd and stores
+a download URL from the server in `urls` field.
+
+Each sabakan server watches meta data in etcd, and finds new assets.
+When a server finds a new asset, it downloads the asset through a URL in `urls`.
+After the server pulled the asset, it may optionally add a URL to download the
+asset from itself for load-balancing.
+
+### Removing assets
+
+When a key is removed, the corresponding asset file will also be removed.
+When a key is updated, the old asset file will be removed.
+
+### Downloading assets
+
+Clients can download assets from any sabakan server.  If a sabakan server
+accepts an asset download request but has no local copy of it, the server
+redirects the request to a server in `urls` field.

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -25,7 +25,6 @@ Meta data of assets are stored in etcd as follows:
         "http://10.1.2.3:10080/api/v1/assets/hoge.tar.gz",
         "http://10.98.76.54:10080/api/v1/assets/hoge.tar.gz"
     ],
-    "version": 1,
     "exists": true
 }
 ```
@@ -35,10 +34,6 @@ updated, a new `id` will be assigned.
 
 `urls` is a list of URLs where the asset can be downloaded.
 Details are described in the next section.
-
-`version` is only meaningful when this JSON is returned from a REST API.
-It indicates how many times the key was updated.  Internally, it is [the
-version of the key](https://coreos.com/etcd/docs/latest/learning/api.html#key-value-pair).
 
 `exists` is only meaningful when this JSON is returned from a REST API.
 It becomes `true` if the server has a local copy of the asset.

--- a/docs/image_management.md
+++ b/docs/image_management.md
@@ -18,7 +18,7 @@ How it works
 
 ### Image directory
 
-sabakan saves uploaded images under `/var/lib/sabakan/OS` directory.
+sabakan saves uploaded images under `/var/lib/sabakan/images/OS` directory.
 `OS` can be an arbitrary identifier such as "coreos".
 
 ### Index of images
@@ -59,13 +59,13 @@ It becomes `true` if the server has a local copy of the image.
 Firstly, only one sabakan server in the cluster has a new image.
 Other sabakan servers need to pull the image from the first server.
 
+To distribute new images, the first server update the index in etcd and
+stores a download URL from the server in `urls` field.
+
 Each sabakan server watches the index in etcd, and finds new images.
 When a server finds a new image in the index, it downloads the image through
 a URL in `urls`.  After the server pulled the image, it may optionally add
 a URL to download the image from itself for load-balancing.
-
-To distribute new images, the first server that receives a new image
-adds an index entry having a download URL from the server in `urls`.
 
 ### Removing images that are no longer in the index
 

--- a/docs/sabactl.md
+++ b/docs/sabactl.md
@@ -125,6 +125,35 @@ Delete an image.
 
 * `-os`: specifies OS of the image.  Default is "coreos"
 
+`sabactl assets index`
+----------------------
+
+Get the index of assets as a JSON array of asset names.
+
+`sabactl assets info NAME`
+--------------------------
+
+Get the meta data of the named asset.
+
+`sabactl assets upload NAME FILE`
+---------------------------------
+
+```console
+$ sabactl assets upload data.tar.gz /path/to/data.tar.gz
+```
+
+Upload an asset.  NAME is the asset filename.
+The data is read from FILE.
+
+`sabactl assets delete NAME`
+----------------------------
+
+```console
+$ sabactl assets delete data.tar.gz
+```
+
+Delete an asset.
+
 `sabactl ignitions get ROLE`
 ----------------------------
 

--- a/docs/sabakan.md
+++ b/docs/sabakan.md
@@ -13,6 +13,8 @@ Usage of /home/ymmt/go/bin/sabakan:
         comma-separated IPs allowed to change resources (default "127.0.0.1,::1")
   -config-file string
         path to configuration file
+  -data-dir string
+        directory to store boot images and assets (default "/var/lib/sabakan")
   -dhcp-bind string
         bound ip addresses and port for dhcp server (default "0.0.0.0:10067")
   -etcd-password string
@@ -27,8 +29,6 @@ Usage of /home/ymmt/go/bin/sabakan:
         username for etcd authentication
   -http string
         <Listen IP>:<Port number> (default "0.0.0.0:10080")
-  -image-dir string
-        directory to store boot images (default "/var/lib/sabakan")
   -ipxe-efi-path string
         path to ipxe.efi (default "/usr/lib/ipxe/ipxe.efi")
   -logfile string
@@ -51,7 +51,7 @@ Option          | Default value            | Description
 `etcd-username` | ""                       | username for etcd authentication
 `etcd-password` | ""                       | password for etcd authentication
 `http`          | `0.0.0.0:10080`          | Listen IP:Port number
-`image-dir`     | `/var/lib/sabakan`       | Directory to store boot images.
+`data-dir`      | `/var/lib/sabakan`       | Directory to store files.
 `ipxe-efi-path` | `/usr/lib/ipxe/ipxe.efi` | path to ipxe.efi
 
 Config file

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -93,8 +93,8 @@ This type of key holds a list of deleted image IDs as follows:
 ["123.45.6", "789.0.1", "2018.04.01"]
 ```
 
-`<prefix>/assets`
------------------
+`<prefix>/assets/`
+------------------
 
 This key stores the last ID of the asset.  Each time an asset is added
 or updated, the value will be incremented by one.
@@ -123,7 +123,7 @@ This type of key holds DHCP configurations.
 The value is [DHCPConfig](dhcp.md#dhcpconfig) formatted in JSON.
 
 `<prefix>/lease-usages/<ip>`
-------------------------------
+----------------------------
 
 Name | Description
 ---- | -----------

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -93,6 +93,18 @@ This type of key holds a list of deleted image IDs as follows:
 ["123.45.6", "789.0.1", "2018.04.01"]
 ```
 
+`<prefix>/assets`
+-----------------
+
+This key stores the last ID of the asset.  Each time an asset is added
+or updated, the value will be incremented by one.
+
+`<prefix>/assets/<NAME>`
+------------------------
+
+This type of key holds the meta data of an asset.
+The value is described in [asset management](assets.md).
+
 `<prefix>/ignitions/<role>/<id>`
 -------------------------
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -93,8 +93,8 @@ This type of key holds a list of deleted image IDs as follows:
 ["123.45.6", "789.0.1", "2018.04.01"]
 ```
 
-`<prefix>/assets/`
-------------------
+`<prefix>/assets`
+-----------------
 
 This key stores the last ID of the asset.  Each time an asset is added
 or updated, the value will be incremented by one.

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -85,21 +85,16 @@ func TestMain(m *testing.M) {
 }
 
 func runSabakan() (func(), error) {
-	servers := etcdClientURL
-	if circleci {
-		servers = "http://localhost:2379"
-	}
-
-	imageDir, err := ioutil.TempDir("", "")
+	dataDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		return nil, err
 	}
 
 	command := exec.Command("../sabakan",
 		"-dhcp-bind", "0.0.0.0:10067",
-		"-etcd-servers", servers,
+		"-etcd-servers", etcdClientURL,
 		"-advertise-url", "http://localhost:10080",
-		"-image-dir", imageDir,
+		"-data-dir", dataDir,
 	)
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
@@ -117,7 +112,7 @@ func runSabakan() (func(), error) {
 			return func() {
 				command.Process.Kill()
 				command.Wait()
-				os.RemoveAll(imageDir)
+				os.RemoveAll(dataDir)
 			}, nil
 		}
 		time.Sleep(1 * time.Second)

--- a/model.go
+++ b/model.go
@@ -70,7 +70,7 @@ type AssetModel interface {
 	GetInfo(ctx context.Context, name string) (*Asset, error)
 	Put(ctx context.Context, name, contentType string, r io.Reader) (*AssetStatus, error)
 	Get(ctx context.Context, name string,
-		f func(modtime time.Time, content io.ReadSeeker)) error
+		f func(modtime time.Time, contentType string, content io.ReadSeeker)) error
 	Delete(ctx context.Context, name string) error
 }
 

--- a/model.go
+++ b/model.go
@@ -64,6 +64,16 @@ type ImageModel interface {
 		f func(modtime time.Time, content io.ReadSeeker)) error
 }
 
+// AssetModel is an interface to manage assets.
+type AssetModel interface {
+	GetIndex(ctx context.Context) ([]string, error)
+	GetInfo(ctx context.Context, name string) (*Asset, error)
+	Put(ctx context.Context, name, contentType string, r io.Reader) (*AssetStatus, error)
+	Get(ctx context.Context, name string,
+		f func(modtime time.Time, content io.ReadSeeker)) error
+	Delete(ctx context.Context, name string) error
+}
+
 // IgnitionModel is an interface for ignition template.
 type IgnitionModel interface {
 	PutTemplate(ctx context.Context, role string, template string) (string, error)
@@ -95,5 +105,6 @@ type Model struct {
 	IPAM     IPAMModel
 	DHCP     DHCPModel
 	Image    ImageModel
+	Asset    AssetModel
 	Ignition IgnitionModel
 }

--- a/model.go
+++ b/model.go
@@ -64,13 +64,18 @@ type ImageModel interface {
 		f func(modtime time.Time, content io.ReadSeeker)) error
 }
 
+// AssetHandler is an interface for AssetModel.Get
+type AssetHandler interface {
+	ServeContent(asset *Asset, content io.ReadSeeker)
+	Redirect(url string)
+}
+
 // AssetModel is an interface to manage assets.
 type AssetModel interface {
 	GetIndex(ctx context.Context) ([]string, error)
 	GetInfo(ctx context.Context, name string) (*Asset, error)
 	Put(ctx context.Context, name, contentType string, r io.Reader) (*AssetStatus, error)
-	Get(ctx context.Context, name string,
-		f func(modtime time.Time, contentType string, content io.ReadSeeker)) error
+	Get(ctx context.Context, name string, h AssetHandler) error
 	Delete(ctx context.Context, name string) error
 }
 

--- a/model.go
+++ b/model.go
@@ -74,7 +74,7 @@ type AssetHandler interface {
 type AssetModel interface {
 	GetIndex(ctx context.Context) ([]string, error)
 	GetInfo(ctx context.Context, name string) (*Asset, error)
-	Put(ctx context.Context, name, contentType string, r io.Reader) (*AssetStatus, error)
+	Put(ctx context.Context, name, contentType, csum string, r io.Reader) (*AssetStatus, error)
 	Get(ctx context.Context, name string, h AssetHandler) error
 	Delete(ctx context.Context, name string) error
 }

--- a/model.go
+++ b/model.go
@@ -74,7 +74,7 @@ type AssetHandler interface {
 type AssetModel interface {
 	GetIndex(ctx context.Context) ([]string, error)
 	GetInfo(ctx context.Context, name string) (*Asset, error)
-	Put(ctx context.Context, name, contentType, csum string, r io.Reader) (*AssetStatus, error)
+	Put(ctx context.Context, name, contentType string, csum []byte, r io.Reader) (*AssetStatus, error)
 	Get(ctx context.Context, name string, h AssetHandler) error
 	Delete(ctx context.Context, name string) error
 }

--- a/models/etcd/asset.go
+++ b/models/etcd/asset.go
@@ -151,7 +151,7 @@ func (d *driver) assetPut(ctx context.Context, name, contentType, csum string, r
 		return nil, err
 	}
 	if !tresp.Succeeded {
-		os.Remove(dir.Path(id))
+		dir.Remove(id)
 		return nil, sabakan.ErrConflicted
 	}
 

--- a/models/etcd/asset.go
+++ b/models/etcd/asset.go
@@ -1,0 +1,261 @@
+package etcd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/clientv3util"
+	"github.com/cybozu-go/sabakan"
+)
+
+func (d *driver) assetDir() string {
+	return filepath.Join(d.dataDir, "assets")
+}
+
+func (d *driver) assetPath(id int) string {
+	return filepath.Join(d.assetDir(), strconv.Itoa(id))
+}
+
+func (d *driver) assetExists(id int) bool {
+	_, err := os.Stat(d.assetPath(id))
+	return err == nil
+}
+
+func (d *driver) assetNewID(ctx context.Context) (int, error) {
+RETRY:
+	resp, err := d.client.Get(ctx, KeyAssets)
+	if err != nil {
+		return 0, err
+	}
+	if resp.Count == 0 {
+		_, err := d.client.Txn(ctx).
+			If(clientv3util.KeyMissing(KeyAssets)).
+			Then(clientv3.OpPut(KeyAssets, "0")).
+			Commit()
+		if err != nil {
+			return 0, err
+		}
+		goto RETRY
+	}
+
+	rev := resp.Kvs[0].ModRevision
+	id, err := strconv.Atoi(string(resp.Kvs[0].Value))
+	if err != nil {
+		return 0, err
+	}
+	id++
+	value := strconv.Itoa(id)
+
+	tresp, err := d.client.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(KeyAssets), "=", rev)).
+		Then(clientv3.OpPut(KeyAssets, value)).
+		Commit()
+	if err != nil {
+		return 0, err
+	}
+	if !tresp.Succeeded {
+		goto RETRY
+	}
+	return id, nil
+}
+
+func (d *driver) assetGetIndex(ctx context.Context) ([]string, error) {
+	resp, err := d.client.Get(ctx, KeyAssets,
+		clientv3.WithPrefix(),
+		clientv3.WithKeysOnly(),
+		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]string, resp.Count)
+	for i, kv := range resp.Kvs {
+		ret[i] = string(kv.Key[len(KeyAssets):])
+	}
+	return ret, nil
+}
+
+func (d *driver) assetGetInfo(ctx context.Context, name string) (*sabakan.Asset, error) {
+	key := KeyAssets + name
+	resp, err := d.client.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Count == 0 {
+		return nil, sabakan.ErrNotFound
+	}
+
+	a := new(sabakan.Asset)
+	err = json.Unmarshal(resp.Kvs[0].Value, a)
+	if err != nil {
+		return nil, err
+	}
+
+	a.Exists = d.assetExists(a.ID)
+
+	return a, nil
+}
+
+func (d *driver) assetPut(ctx context.Context, name, contentType string, r io.Reader) (*sabakan.AssetStatus, error) {
+	id, err := d.assetNewID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	dir := d.assetDir()
+	err = os.MkdirAll(dir, 0755)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := ioutil.TempFile(dir, ".tmp")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	w := io.MultiWriter(f, h)
+	_, err = io.Copy(w, r)
+	if err != nil {
+		return nil, err
+	}
+	err = f.Sync()
+	if err != nil {
+		return nil, err
+	}
+
+	dest := d.assetPath(id)
+	err = os.Rename(f.Name(), dest)
+	if err != nil {
+		return nil, err
+	}
+
+	a := &sabakan.Asset{
+		Name:        name,
+		ID:          id,
+		ContentType: contentType,
+		Date:        time.Now().UTC(),
+		Sha256:      hex.EncodeToString(h.Sum(nil)),
+		URLs:        []string{d.myURL("/api/v1/assets", name)},
+	}
+	data, err := json.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+
+	key := KeyAssets + name
+	resp, err := d.client.Get(ctx, key, clientv3.WithKeysOnly())
+	if err != nil {
+		return nil, err
+	}
+
+	ifop := clientv3util.KeyMissing(key)
+	retStatus := http.StatusCreated
+
+	if resp.Count != 0 {
+		rev := resp.Kvs[0].ModRevision
+		ifop = clientv3.Compare(clientv3.ModRevision(key), "=", rev)
+		retStatus = http.StatusOK
+	}
+
+	tresp, err := d.client.Txn(ctx).
+		If(ifop).Then(clientv3.OpPut(key, string(data))).Commit()
+	if err != nil {
+		return nil, err
+	}
+	if !tresp.Succeeded {
+		os.Remove(dest)
+		return nil, sabakan.ErrConflicted
+	}
+
+	return &sabakan.AssetStatus{
+		Status: retStatus,
+		ID:     id,
+	}, nil
+}
+
+func (d *driver) assetGet(ctx context.Context, name string, h sabakan.AssetHandler) error {
+	key := KeyAssets + name
+	resp, err := d.client.Get(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	if resp.Count == 0 {
+		return sabakan.ErrNotFound
+	}
+
+	a := new(sabakan.Asset)
+	err = json.Unmarshal(resp.Kvs[0].Value, a)
+	if err != nil {
+		return err
+	}
+
+	if d.assetExists(a.ID) {
+		g, err := os.Open(d.assetPath(a.ID))
+		if err != nil {
+			return err
+		}
+		defer g.Close()
+
+		h.ServeContent(a, g)
+		return nil
+	}
+
+	h.Redirect(a.URLs[rand.Intn(len(a.URLs))])
+	return nil
+}
+
+func (d *driver) assetDelete(ctx context.Context, name string) error {
+	key := KeyAssets + name
+	resp, err := d.client.Txn(ctx).
+		If(clientv3util.KeyExists(key)).
+		Then(clientv3.OpDelete(key)).
+		Commit()
+
+	if err != nil {
+		return err
+	}
+
+	if !resp.Succeeded {
+		return sabakan.ErrNotFound
+	}
+	return nil
+}
+
+type assetDriver struct {
+	*driver
+}
+
+func (d assetDriver) GetIndex(ctx context.Context) ([]string, error) {
+	return d.assetGetIndex(ctx)
+}
+
+func (d assetDriver) GetInfo(ctx context.Context, name string) (*sabakan.Asset, error) {
+	return d.assetGetInfo(ctx, name)
+}
+
+func (d assetDriver) Put(ctx context.Context, name, contentType string, r io.Reader) (*sabakan.AssetStatus, error) {
+	return d.assetPut(ctx, name, contentType, r)
+}
+
+func (d assetDriver) Get(ctx context.Context, name string, h sabakan.AssetHandler) error {
+	return d.assetGet(ctx, name, h)
+}
+
+func (d assetDriver) Delete(ctx context.Context, name string) error {
+	return d.assetDelete(ctx, name)
+}

--- a/models/etcd/asset.go
+++ b/models/etcd/asset.go
@@ -34,14 +34,14 @@ func (d *driver) assetExists(id int) bool {
 
 func (d *driver) assetNewID(ctx context.Context) (int, error) {
 RETRY:
-	resp, err := d.client.Get(ctx, KeyAssets)
+	resp, err := d.client.Get(ctx, KeyAssetsID)
 	if err != nil {
 		return 0, err
 	}
 	if resp.Count == 0 {
 		_, err := d.client.Txn(ctx).
-			If(clientv3util.KeyMissing(KeyAssets)).
-			Then(clientv3.OpPut(KeyAssets, "0")).
+			If(clientv3util.KeyMissing(KeyAssetsID)).
+			Then(clientv3.OpPut(KeyAssetsID, "0")).
 			Commit()
 		if err != nil {
 			return 0, err
@@ -58,8 +58,8 @@ RETRY:
 	value := strconv.Itoa(id)
 
 	tresp, err := d.client.Txn(ctx).
-		If(clientv3.Compare(clientv3.ModRevision(KeyAssets), "=", rev)).
-		Then(clientv3.OpPut(KeyAssets, value)).
+		If(clientv3.Compare(clientv3.ModRevision(KeyAssetsID), "=", rev)).
+		Then(clientv3.OpPut(KeyAssetsID, value)).
 		Commit()
 	if err != nil {
 		return 0, err

--- a/models/etcd/asset.go
+++ b/models/etcd/asset.go
@@ -105,7 +105,7 @@ func (d *driver) assetGetInfo(ctx context.Context, name string) (*sabakan.Asset,
 	return a, err
 }
 
-func (d *driver) assetPut(ctx context.Context, name, contentType, csum string, r io.Reader) (*sabakan.AssetStatus, error) {
+func (d *driver) assetPut(ctx context.Context, name, contentType string, csum []byte, r io.Reader) (*sabakan.AssetStatus, error) {
 	id, err := d.assetNewID(ctx)
 	if err != nil {
 		return nil, err
@@ -224,7 +224,7 @@ func (d assetDriver) GetInfo(ctx context.Context, name string) (*sabakan.Asset, 
 	return d.assetGetInfo(ctx, name)
 }
 
-func (d assetDriver) Put(ctx context.Context, name, contentType, csum string, r io.Reader) (*sabakan.AssetStatus, error) {
+func (d assetDriver) Put(ctx context.Context, name, contentType string, csum []byte, r io.Reader) (*sabakan.AssetStatus, error) {
 	return d.assetPut(ctx, name, contentType, csum, r)
 }
 

--- a/models/etcd/asset_dir.go
+++ b/models/etcd/asset_dir.go
@@ -1,0 +1,95 @@
+package etcd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/cybozu-go/log"
+)
+
+// AssetDir is a struct to manage the assets directory.
+type AssetDir struct {
+	Dir string
+}
+
+// Path returns a path to an asset of id.
+func (d AssetDir) Path(id int) string {
+	return filepath.Join(d.Dir, strconv.Itoa(id))
+}
+
+// Exists returns true if a local copy of an asset of id exists.
+func (d AssetDir) Exists(id int) bool {
+	_, err := os.Stat(d.Path(id))
+	return err == nil
+}
+
+// Save stores an asset.
+// When successful, this returns SHA256 checksum of the contents.
+func (d AssetDir) Save(id int, r io.Reader, csum string) ([]byte, error) {
+	err := os.MkdirAll(d.Dir, 0755)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := ioutil.TempFile(d.Dir, ".tmp")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	w := io.MultiWriter(f, h)
+	_, err = io.Copy(w, r)
+	if err != nil {
+		return nil, err
+	}
+
+	hsum := h.Sum(nil)
+	if len(csum) > 0 && hex.EncodeToString(hsum) != csum {
+		os.Remove(f.Name())
+		return nil, fmt.Errorf("checksum mismatch for id %d", id)
+	}
+
+	err = f.Sync()
+	if err != nil {
+		return nil, err
+	}
+
+	dest := d.Path(id)
+	err = os.Rename(f.Name(), dest)
+	if err != nil {
+		return nil, err
+	}
+
+	return hsum, nil
+}
+
+// GC removes garbage, that is, files whose names are not in ids.
+func (d AssetDir) GC(ids map[int]bool) error {
+	fil, err := ioutil.ReadDir(d.Dir)
+	if err != nil {
+		return err
+	}
+
+	for _, fi := range fil {
+		if !fi.Mode().IsRegular() {
+			continue
+		}
+
+		id, err := strconv.Atoi(fi.Name())
+		if err != nil || !ids[id] {
+			log.Info("removing garbage asset", map[string]interface{}{
+				"name": fi.Name(),
+			})
+			os.Remove(filepath.Join(d.Dir, fi.Name()))
+		}
+	}
+
+	return nil
+}

--- a/models/etcd/asset_dir.go
+++ b/models/etcd/asset_dir.go
@@ -1,8 +1,8 @@
 package etcd
 
 import (
+	"bytes"
 	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -36,7 +36,7 @@ func (d AssetDir) Remove(id int) error {
 
 // Save stores an asset.
 // When successful, this returns SHA256 checksum of the contents.
-func (d AssetDir) Save(id int, r io.Reader, csum string) ([]byte, error) {
+func (d AssetDir) Save(id int, r io.Reader, csum []byte) ([]byte, error) {
 	err := os.MkdirAll(d.Dir, 0755)
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func (d AssetDir) Save(id int, r io.Reader, csum string) ([]byte, error) {
 	}
 
 	hsum := h.Sum(nil)
-	if len(csum) > 0 && hex.EncodeToString(hsum) != csum {
+	if csum != nil && !bytes.Equal(csum, hsum) {
 		os.Remove(f.Name())
 		return nil, fmt.Errorf("checksum mismatch for id %d", id)
 	}

--- a/models/etcd/asset_dir.go
+++ b/models/etcd/asset_dir.go
@@ -29,6 +29,11 @@ func (d AssetDir) Exists(id int) bool {
 	return err == nil
 }
 
+// Remove removes an asset.
+func (d AssetDir) Remove(id int) error {
+	return os.Remove(d.Path(id))
+}
+
 // Save stores an asset.
 // When successful, this returns SHA256 checksum of the contents.
 func (d AssetDir) Save(id int, r io.Reader, csum string) ([]byte, error) {

--- a/models/etcd/asset_test.go
+++ b/models/etcd/asset_test.go
@@ -1,0 +1,57 @@
+package etcd
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func testAssetGetIndex(t *testing.T) {
+	t.Parallel()
+
+	d, _ := testNewDriver(t)
+
+	tempdir, err := ioutil.TempDir("", "sabakan-asset-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.dataDir = tempdir
+	defer os.RemoveAll(tempdir)
+
+	index, err := d.assetGetIndex(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(index) != 0 {
+		t.Error("asset index should be empty")
+	}
+
+	_, err = d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = d.assetPut(context.Background(), "abc", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = d.assetPut(context.Background(), "xyz", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	index, err = d.assetGetIndex(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// index must be sorted
+	if !reflect.DeepEqual(index, []string{"abc", "foo", "xyz"}) {
+		t.Error("wrong asset index:", index)
+	}
+}
+
+func TestAsset(t *testing.T) {
+	t.Run("GetIndex", testAssetGetIndex)
+}

--- a/models/etcd/asset_test.go
+++ b/models/etcd/asset_test.go
@@ -2,11 +2,15 @@ package etcd
 
 import (
 	"context"
+	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/cybozu-go/sabakan"
 )
 
 func testAssetGetIndex(t *testing.T) {
@@ -26,7 +30,7 @@ func testAssetGetIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(index) != 0 {
-		t.Error("asset index should be empty")
+		t.Error("initial asset index should be empty")
 	}
 
 	_, err = d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
@@ -52,6 +56,255 @@ func testAssetGetIndex(t *testing.T) {
 	}
 }
 
+func testAssetGetInfo(t *testing.T) {
+	t.Parallel()
+
+	d, _ := testNewDriver(t)
+
+	tempdir, err := ioutil.TempDir("", "sabakan-asset-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.dataDir = tempdir
+	defer os.RemoveAll(tempdir)
+
+	_, err = d.assetGetInfo(context.Background(), "foo")
+	if err != sabakan.ErrNotFound {
+		t.Error("err != sabakan.ErrNotFound:", err)
+	}
+
+	_, err = d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	asset, err := d.assetGetInfo(context.Background(), "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if asset.Name != "foo" {
+		t.Error("asset.Name != foo:", asset.Name)
+	}
+	if asset.ID != 1 {
+		t.Error("asset.ID != 1:", asset.ID)
+	}
+	if asset.ContentType != "text/plain" {
+		t.Error("asset.ContentType != text/plain:", asset.ContentType)
+	}
+	if asset.Sha256 != "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9" {
+		t.Error("wrong Sha256:", asset.Sha256)
+	}
+	u := *d.advertiseURL
+	u.Path = "/api/v1/assets/foo"
+	if !reflect.DeepEqual(asset.URLs, []string{u.String()}) {
+		t.Error("wrong URLs", asset.URLs)
+	}
+	if !asset.Exists {
+		t.Error("file must exist locally")
+	}
+
+	// force local copy absent
+	// this may cause watcher to panic, so stop it beforehand
+	err = os.Remove(d.assetPath(asset.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	asset, err = d.assetGetInfo(context.Background(), "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if asset.Exists {
+		t.Error("file must not exist")
+	}
+}
+
+func testAssetPut(t *testing.T) {
+	t.Parallel()
+
+	d, _ := testNewDriver(t)
+
+	tempdir, err := ioutil.TempDir("", "sabakan-asset-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.dataDir = tempdir
+	defer os.RemoveAll(tempdir)
+
+	status, err := d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status.Status != http.StatusCreated {
+		t.Error("status.Status != http.StatusCreated:", status.Status)
+	}
+	if status.ID != 1 {
+		t.Error("status.ID != 1:", status.ID)
+	}
+
+	status, err = d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("baz"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status.Status != http.StatusOK {
+		t.Error("status.Status != http.StatusOK:", status.Status)
+	}
+	if status.ID != 2 {
+		t.Error("status.ID != 2:", status.ID)
+	}
+
+	f, err := os.Open(d.assetPath(status.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != "baz" {
+		t.Error("local copy corrupted")
+	}
+}
+
+type mockHandler struct {
+	calledServeContent bool
+	calledRedirect     bool
+	err                error
+	asset              *sabakan.Asset
+	content            []byte
+	redirectURL        string
+}
+
+func (h *mockHandler) ServeContent(asset *sabakan.Asset, content io.ReadSeeker) {
+	h.calledServeContent = true
+	h.asset = asset
+	buf, err := ioutil.ReadAll(content)
+	if err != nil {
+		h.err = err
+		return
+	}
+	h.content = buf
+}
+
+func (h *mockHandler) Redirect(url string) {
+	h.calledRedirect = true
+	h.redirectURL = url
+}
+
+func testAssetGet(t *testing.T) {
+	t.Parallel()
+
+	d, _ := testNewDriver(t)
+
+	tempdir, err := ioutil.TempDir("", "sabakan-asset-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.dataDir = tempdir
+	defer os.RemoveAll(tempdir)
+
+	h := new(mockHandler)
+	err = d.assetGet(context.Background(), "foo", h)
+	if err != sabakan.ErrNotFound {
+		t.Error("err != sabakan.ErrNotFound:", err)
+	}
+
+	status, err := d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h = new(mockHandler)
+	err = d.assetGet(context.Background(), "foo", h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.err != nil {
+		t.Fatal(err)
+	}
+	if !h.calledServeContent {
+		t.Error("ServeContent() was not called")
+	}
+	if h.asset == nil || h.asset.ID != status.ID {
+		t.Error("ServeContent() received wrong asset")
+	}
+	if string(h.content) != "bar" {
+		t.Error("ServeContent() received wrong content")
+	}
+
+	// force local copy absent
+	// this may cause watcher to panic, so stop it beforehand
+	err = os.Remove(d.assetPath(status.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h = new(mockHandler)
+	err = d.assetGet(context.Background(), "foo", h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.err != nil {
+		t.Fatal(err)
+	}
+	if !h.calledRedirect {
+		t.Error("Redirect() was not called")
+	}
+	u := *d.advertiseURL
+	u.Path = "/api/v1/assets/foo"
+	// it's nonsense to redirect to myself; just for test
+	if h.redirectURL != u.String() {
+		t.Error("Redirect() received wrong URL:", h.redirectURL)
+	}
+}
+
+func testAssetDelete(t *testing.T) {
+	t.Parallel()
+
+	d, _ := testNewDriver(t)
+
+	tempdir, err := ioutil.TempDir("", "sabakan-asset-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.dataDir = tempdir
+	defer os.RemoveAll(tempdir)
+
+	err = d.assetDelete(context.Background(), "foo")
+	if err != sabakan.ErrNotFound {
+		t.Error("err != sabakan.ErrNotFound:", err)
+	}
+
+	_, err = d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = d.assetDelete(context.Background(), "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = d.assetGetInfo(context.Background(), "foo")
+	if err != sabakan.ErrNotFound {
+		t.Error("err != sabakan.ErrNotFound:", err)
+	}
+
+	status, err := d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("baz"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Status != http.StatusCreated {
+		t.Error("status.Status != http.StatusCreated:", status.Status)
+	}
+}
+
 func TestAsset(t *testing.T) {
 	t.Run("GetIndex", testAssetGetIndex)
+	t.Run("GetInfo", testAssetGetInfo)
+	t.Run("Put", testAssetPut)
+	t.Run("Get", testAssetGet)
+	t.Run("Delete", testAssetDelete)
 }

--- a/models/etcd/asset_test.go
+++ b/models/etcd/asset_test.go
@@ -106,7 +106,6 @@ func testAssetGetInfo(t *testing.T) {
 	}
 
 	// force local copy absent
-	// TODO: this may cause watcher to panic, so stop it beforehand
 	err = os.Remove(d.getAssetDir().Path(asset.ID))
 	if err != nil {
 		t.Fatal(err)
@@ -330,7 +329,6 @@ func testAssetGet(t *testing.T) {
 	}
 
 	// force local copy absent
-	// TODO: this may cause watcher to panic, so stop it beforehand
 	err = os.Remove(d.getAssetDir().Path(status.ID))
 	if err != nil {
 		t.Fatal(err)
@@ -395,8 +393,6 @@ func testAssetDelete(t *testing.T) {
 	if len(resp.Kvs) != 0 {
 		t.Error("asset not deleted from etcd; len(resp.Kvs) != 0:", len(resp.Kvs))
 	}
-
-	// TODO: check local file directly; this needs watcher
 
 	status, err := d.assetPut(context.Background(), "foo", "text/plain", nil, strings.NewReader("baz"))
 	if err != nil {

--- a/models/etcd/asset_test.go
+++ b/models/etcd/asset_test.go
@@ -34,15 +34,15 @@ func testAssetGetIndex(t *testing.T) {
 		t.Error("initial asset index should be empty")
 	}
 
-	_, err = d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	_, err = d.assetPut(context.Background(), "foo", "text/plain", "", strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = d.assetPut(context.Background(), "abc", "text/plain", strings.NewReader("bar"))
+	_, err = d.assetPut(context.Background(), "abc", "text/plain", "", strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = d.assetPut(context.Background(), "xyz", "text/plain", strings.NewReader("bar"))
+	_, err = d.assetPut(context.Background(), "xyz", "text/plain", "", strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func testAssetGetInfo(t *testing.T) {
 		t.Error("err != sabakan.ErrNotFound:", err)
 	}
 
-	_, err = d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	_, err = d.assetPut(context.Background(), "foo", "text/plain", "", strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func testAssetGetInfo(t *testing.T) {
 
 	// force local copy absent
 	// TODO: this may cause watcher to panic, so stop it beforehand
-	err = os.Remove(d.assetPath(asset.ID))
+	err = os.Remove(d.getAssetDir().Path(asset.ID))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func testAssetPut(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 
 	// case 1. creation
-	status, err := d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	status, err := d.assetPut(context.Background(), "foo", "text/plain", "", strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func testAssetPut(t *testing.T) {
 	// asset.Exists in etcd has no meaning
 
 	// check local file directly
-	f1, err := os.Open(d.assetPath(status.ID))
+	f1, err := os.Open(d.getAssetDir().Path(status.ID))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func testAssetPut(t *testing.T) {
 	}
 
 	// case 2. update
-	status, err = d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("baz"))
+	status, err = d.assetPut(context.Background(), "foo", "text/plain", "", strings.NewReader("baz"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +231,7 @@ func testAssetPut(t *testing.T) {
 		t.Error("wrong URLs", asset.URLs)
 	}
 
-	f2, err := os.Open(d.assetPath(status.ID))
+	f2, err := os.Open(d.getAssetDir().Path(status.ID))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ func testAssetGet(t *testing.T) {
 		t.Error("err != sabakan.ErrNotFound:", err)
 	}
 
-	status, err := d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	status, err := d.assetPut(context.Background(), "foo", "text/plain", "", strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -313,7 +313,7 @@ func testAssetGet(t *testing.T) {
 
 	// force local copy absent
 	// TODO: this may cause watcher to panic, so stop it beforehand
-	err = os.Remove(d.assetPath(status.ID))
+	err = os.Remove(d.getAssetDir().Path(status.ID))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -354,7 +354,7 @@ func testAssetDelete(t *testing.T) {
 		t.Error("err != sabakan.ErrNotFound:", err)
 	}
 
-	_, err = d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	_, err = d.assetPut(context.Background(), "foo", "text/plain", "", strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -380,7 +380,7 @@ func testAssetDelete(t *testing.T) {
 
 	// TODO: check local file directly; this needs watcher
 
-	status, err := d.assetPut(context.Background(), "foo", "text/plain", strings.NewReader("baz"))
+	status, err := d.assetPut(context.Background(), "foo", "text/plain", "", strings.NewReader("baz"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/models/etcd/asset_updater.go
+++ b/models/etcd/asset_updater.go
@@ -2,11 +2,168 @@ package etcd
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"strconv"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/sabakan"
 )
 
+func (d *driver) addAssetURL(ctx context.Context, asset *sabakan.Asset) error {
+RETRY:
+	a, rev, err := d.assetGetInfoWithRev(ctx, asset.Name)
+	if err != nil {
+		if err == sabakan.ErrNotFound {
+			// asset has been deleted
+			return nil
+		}
+		return err
+	}
+
+	// asset has been replaced
+	if a.ID != asset.ID {
+		return nil
+	}
+
+	a.URLs = append(a.URLs, d.myURL("/api/v1/assets", a.Name))
+	key := KeyAssets + a.Name
+
+	j, err := json.Marshal(a)
+	if err != nil {
+		return err
+	}
+
+	resp, err := d.client.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(key), "=", rev)).
+		Then(clientv3.OpPut(key, string(j))).
+		Commit()
+	if err != nil {
+		return err
+	}
+	if !resp.Succeeded {
+		goto RETRY
+	}
+
+	return nil
+}
+
+func (d *driver) downloadAsset(ctx context.Context, asset *sabakan.Asset) error {
+	urls := make([]string, len(asset.URLs))
+	for i, v := range rand.Perm(len(urls)) {
+		urls[v] = asset.URLs[i]
+	}
+
+	var resp *http.Response
+	var err error
+
+	for _, u := range urls {
+		resp, err = d.pullURL(ctx, u)
+		if err == nil {
+			break
+		}
+	}
+
+	if err != nil {
+		log.Error("failed to pull an asset", map[string]interface{}{
+			"name": asset.Name,
+			"id":   asset.ID,
+			"urls": asset.URLs,
+		})
+		return err
+	}
+	defer func() {
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	id, err := strconv.Atoi(resp.Header.Get("X-Sabakan-Asset-ID"))
+	if err != nil {
+		log.Error("invalid asset ID", map[string]interface{}{
+			log.FnError: err,
+			"id":        resp.Header.Get("X-Sabakan-Asset-ID"),
+		})
+		return errors.New("invalid asset ID")
+	}
+	csum := resp.Header.Get("X-Sabakan-Asset-SHA256")
+
+	if asset.ID != id {
+		// the asset has been replaced with newer one
+		log.Info("received newer asset", map[string]interface{}{
+			"expected": asset.ID,
+			"received": id,
+			"name":     asset.Name,
+		})
+		return nil
+	}
+
+	_, err = d.getAssetDir().Save(id, resp.Body, csum)
+	if err != nil {
+		return err
+	}
+
+	if len(asset.URLs) < maxAssetURLs {
+		err = d.addAssetURL(ctx, asset)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (d *driver) initAssets(ctx context.Context, rev int64) error {
+	resp, err := d.client.Get(ctx, KeyAssets,
+		clientv3.WithPrefix(),
+		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
+		clientv3.WithLimit(assetPageSize),
+		clientv3.WithRev(rev))
+	if err != nil {
+		return err
+	}
+
+	dir := d.getAssetDir()
+	ids := make(map[int]bool)
+	kvs := resp.Kvs
+
+REDO:
+	for _, kv := range kvs {
+		asset := new(sabakan.Asset)
+		err = json.Unmarshal(kv.Value, asset)
+		if err != nil {
+			return err
+		}
+		ids[asset.ID] = true
+		if dir.Exists(asset.ID) {
+			continue
+		}
+		err = d.downloadAsset(ctx, asset)
+		if err != nil {
+			return err
+		}
+	}
+
+	if resp.More {
+		resp, err = d.client.Get(ctx, string(resp.Kvs[len(resp.Kvs)-1].Key),
+			clientv3.WithRange(clientv3.GetPrefixRangeEnd(KeyAssets)),
+			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
+			clientv3.WithLimit(assetPageSize),
+			clientv3.WithRev(rev))
+		if err != nil {
+			return err
+		}
+
+		// ignore the first key
+		kvs = resp.Kvs[1:]
+		goto REDO
+	}
+
+	dir.GC(ids)
 	return nil
 }
 

--- a/models/etcd/asset_updater.go
+++ b/models/etcd/asset_updater.go
@@ -1,0 +1,30 @@
+package etcd
+
+import (
+	"context"
+
+	"github.com/coreos/etcd/clientv3"
+)
+
+func (d *driver) initAssets(ctx context.Context, rev int64) error {
+	return nil
+}
+
+func (d *driver) handleAssetEvent(ctx context.Context, ev *clientv3.Event) error {
+	return nil
+}
+
+func (d *driver) startAssetUpdater(ctx context.Context, ch <-chan EventPool) error {
+	for ep := range ch {
+		for _, ev := range ep.Events {
+			err := d.handleAssetEvent(ctx, ev)
+			if err != nil {
+				return err
+			}
+		}
+
+		// checkpoint
+		d.saveLastRev(ep.Rev)
+	}
+	return nil
+}

--- a/models/etcd/asset_updater.go
+++ b/models/etcd/asset_updater.go
@@ -280,12 +280,12 @@ func (d *driver) handleAssetEvent(ctx context.Context, ev *clientv3.Event) error
 
 func (d *driver) startAssetUpdater(ctx context.Context, ch <-chan EventPool) error {
 	for ep := range ch {
-		jitter := rand.Intn(maxJitterSeconds)
+		jitter := rand.Intn(maxJitterSeconds * 100)
 		log.Info("asset updater: waiting...", map[string]interface{}{
-			"seconds": jitter,
+			"centiseconds": jitter,
 		})
 		select {
-		case <-time.After(time.Duration(jitter) * time.Second):
+		case <-time.After(time.Duration(jitter) * 10 * time.Millisecond):
 		case <-ctx.Done():
 			return nil
 		}

--- a/models/etcd/asset_updater.go
+++ b/models/etcd/asset_updater.go
@@ -2,6 +2,7 @@ package etcd
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -99,7 +100,10 @@ func (d *driver) downloadAsset(ctx context.Context, asset *sabakan.Asset) error 
 		})
 		return errors.New("invalid asset ID")
 	}
-	csum := resp.Header.Get("X-Sabakan-Asset-SHA256")
+	csum, err := hex.DecodeString(resp.Header.Get("X-Sabakan-Asset-SHA256"))
+	if err != nil {
+		return err
+	}
 
 	if asset.ID != id {
 		// the asset has been replaced with newer one

--- a/models/etcd/constants.go
+++ b/models/etcd/constants.go
@@ -24,7 +24,7 @@ const LastRevFile = "lastrev"
 // Miscellaneous
 const (
 	assetPageSize    = 100
-	maxJitterSeconds = 60
+	maxJitterSeconds = 30
 	maxAssetURLs     = 10
 	maxImageURLs     = 10
 )

--- a/models/etcd/constants.go
+++ b/models/etcd/constants.go
@@ -10,6 +10,7 @@ const (
 	KeyNodeIndices = "node-indices/"
 	KeyImages      = "images/"
 	KeyAssets      = "assets/"
+	KeyAssetsID    = "assets"
 	KeyIgnitions   = "ignitions/"
 )
 

--- a/models/etcd/constants.go
+++ b/models/etcd/constants.go
@@ -3,8 +3,8 @@ package etcd
 // Internal schema keys.
 const (
 	KeyCrypts      = "crypts/"
-	KeyDHCP        = "dhcp/"
-	KeyIPAM        = "ipam/"
+	KeyDHCP        = "dhcp"
+	KeyIPAM        = "ipam"
 	KeyLeaseUsages = "lease-usages/"
 	KeyMachines    = "machines/"
 	KeyNodeIndices = "node-indices/"

--- a/models/etcd/constants.go
+++ b/models/etcd/constants.go
@@ -9,6 +9,7 @@ const (
 	KeyMachines    = "machines/"
 	KeyNodeIndices = "node-indices/"
 	KeyImages      = "images/"
+	KeyAssets      = "assets/"
 	KeyIgnitions   = "ignitions/"
 )
 

--- a/models/etcd/constants.go
+++ b/models/etcd/constants.go
@@ -16,3 +16,15 @@ const (
 
 // MaxDeleted is the maximum number of deleted image IDs stored in etcd.
 const MaxDeleted = 10
+
+// LastRevFile is the filename that keeps the last revision that
+// the stateful watcher processed successfully.
+const LastRevFile = "lastrev"
+
+// Miscellaneous
+const (
+	assetPageSize    = 100
+	maxJitterSeconds = 60
+	maxAssetURLs     = 10
+	maxImageURLs     = 10
+)

--- a/models/etcd/driver.go
+++ b/models/etcd/driver.go
@@ -36,6 +36,7 @@ func NewModel(client *clientv3.Client, dataDir string, advertiseURL *url.URL) sa
 		IPAM:     ipamDriver{d},
 		DHCP:     dhcpDriver{d},
 		Image:    imageDriver{d},
+		Asset:    assetDriver{d},
 		Ignition: d,
 	}
 }

--- a/models/etcd/driver.go
+++ b/models/etcd/driver.go
@@ -14,7 +14,7 @@ import (
 
 type driver struct {
 	client       *clientv3.Client
-	imageDir     string
+	dataDir      string
 	advertiseURL *url.URL
 	mi           *machinesIndex
 	ipamConfig   atomic.Value
@@ -22,10 +22,10 @@ type driver struct {
 }
 
 // NewModel returns sabakan.Model
-func NewModel(client *clientv3.Client, imageDir string, advertiseURL *url.URL) sabakan.Model {
+func NewModel(client *clientv3.Client, dataDir string, advertiseURL *url.URL) sabakan.Model {
 	d := &driver{
 		client:       client,
-		imageDir:     imageDir,
+		dataDir:      dataDir,
 		advertiseURL: advertiseURL,
 		mi:           newMachinesIndex(),
 	}

--- a/models/etcd/image.go
+++ b/models/etcd/image.go
@@ -24,7 +24,7 @@ var (
 
 func (d *driver) getImageDir(os string) ImageDir {
 	return ImageDir{
-		Dir: filepath.Join(d.imageDir, os),
+		Dir: filepath.Join(d.dataDir, "images", os),
 	}
 }
 

--- a/models/etcd/image_test.go
+++ b/models/etcd/image_test.go
@@ -68,7 +68,7 @@ func testImageGetIndex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d.imageDir = tempdir
+	d.dataDir = tempdir
 	defer os.RemoveAll(tempdir)
 
 	index, err := d.imageGetIndex(context.Background(), "coreos")
@@ -108,7 +108,7 @@ func testImageGetIndex(t *testing.T) {
 		}
 	}
 
-	err = os.MkdirAll(filepath.Join(tempdir, "coreos", "1234.5"), 0755)
+	err = os.MkdirAll(filepath.Join(tempdir, "images", "coreos", "1234.5"), 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func testImageUpload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d.imageDir = tempdir
+	d.dataDir = tempdir
 	defer os.RemoveAll(tempdir)
 
 	err = d.imageUpload(context.Background(), "coreos", "1234.5", archive)
@@ -216,7 +216,7 @@ func testImageDownload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d.imageDir = tempdir
+	d.dataDir = tempdir
 	defer os.RemoveAll(tempdir)
 
 	index := sabakan.ImageIndex{
@@ -319,7 +319,7 @@ func testImageDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d.imageDir = tempdir
+	d.dataDir = tempdir
 	defer os.RemoveAll(tempdir)
 
 	index := sabakan.ImageIndex{
@@ -400,7 +400,7 @@ func testImageServeFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d.imageDir = tempdir
+	d.dataDir = tempdir
 	defer os.RemoveAll(tempdir)
 
 	index := sabakan.ImageIndex{

--- a/models/etcd/image_updater.go
+++ b/models/etcd/image_updater.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"math/rand"
-	"net/http"
 	"path"
 	"strings"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/sabakan"
 )
@@ -18,21 +16,6 @@ import (
 type updateData struct {
 	index   sabakan.ImageIndex
 	deleted []string
-}
-
-const (
-	maxJitterSeconds = 60
-	maxImageURLs     = 10
-)
-
-func pullImage(ctx context.Context, client *cmd.HTTPClient, u string) (*http.Response, error) {
-	req, err := http.NewRequest("GET", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req = req.WithContext(ctx)
-	return client.Do(req)
 }
 
 func (d *driver) addImageURL(ctx context.Context, os, id string) error {
@@ -74,7 +57,7 @@ RETRY:
 	return nil
 }
 
-func (d *driver) updateImageForOS(ctx context.Context, client *cmd.HTTPClient, os string, data updateData) error {
+func (d *driver) updateImageForOS(ctx context.Context, os string, data updateData) error {
 	dir := d.getImageDir(os)
 
 	err := dir.GC(data.deleted)
@@ -94,7 +77,7 @@ OUTER:
 		}
 
 		for _, u := range urls {
-			resp, err := pullImage(ctx, client, u)
+			resp, err := d.pullURL(ctx, u)
 			if err != nil {
 				continue
 			}
@@ -131,7 +114,7 @@ OUTER:
 	return nil
 }
 
-func (d *driver) updateImage(ctx context.Context, client *cmd.HTTPClient) error {
+func (d *driver) updateImage(ctx context.Context) error {
 	resp, err := d.client.Get(ctx, KeyImages, clientv3.WithPrefix())
 	if err != nil {
 		return err
@@ -174,7 +157,7 @@ func (d *driver) updateImage(ctx context.Context, client *cmd.HTTPClient) error 
 	}
 
 	for os, data := range dataMap {
-		err = d.updateImageForOS(ctx, client, os, data)
+		err = d.updateImageForOS(ctx, os, data)
 		if err != nil {
 			return err
 		}
@@ -184,12 +167,8 @@ func (d *driver) updateImage(ctx context.Context, client *cmd.HTTPClient) error 
 }
 
 func (d *driver) startImageUpdater(ctx context.Context, ch <-chan struct{}) error {
-	client := &cmd.HTTPClient{
-		Client: &http.Client{},
-	}
-
 	for {
-		err := d.updateImage(ctx, client)
+		err := d.updateImage(ctx)
 		if err != nil {
 			return err
 		}

--- a/models/etcd/image_updater.go
+++ b/models/etcd/image_updater.go
@@ -175,12 +175,12 @@ func (d *driver) startImageUpdater(ctx context.Context, ch <-chan struct{}) erro
 
 		select {
 		case <-ch:
-			jitter := rand.Intn(maxJitterSeconds)
+			jitter := rand.Intn(maxJitterSeconds * 100)
 			log.Info("image updater: waiting...", map[string]interface{}{
-				"seconds": jitter,
+				"centiseconds": jitter,
 			})
 			select {
-			case <-time.After(time.Duration(jitter) * time.Second):
+			case <-time.After(time.Duration(jitter) * 10 * time.Millisecond):
 			case <-ctx.Done():
 				return nil
 			}

--- a/models/etcd/main_test.go
+++ b/models/etcd/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/namespace"
+	"github.com/cybozu-go/cmd"
 )
 
 const (
@@ -88,7 +90,10 @@ func testNewDriver(t *testing.T) (*driver, <-chan struct{}) {
 		t.Fatal(err)
 	}
 	d := &driver{
-		client:       client,
+		client: client,
+		httpclient: &cmd.HTTPClient{
+			Client: &http.Client{},
+		},
 		mi:           newMachinesIndex(),
 		advertiseURL: u,
 	}

--- a/models/etcd/main_test.go
+++ b/models/etcd/main_test.go
@@ -93,7 +93,7 @@ func testNewDriver(t *testing.T) (*driver, <-chan struct{}) {
 		advertiseURL: u,
 	}
 	ch := make(chan struct{}, 8) // buffers post-modify-done signals, up to 8
-	go d.startWatching(context.Background(), ch, nil)
+	go d.startStatelessWatcher(context.Background(), ch, nil)
 	<-ch
 	return d, ch
 }

--- a/models/etcd/watch_stateful.go
+++ b/models/etcd/watch_stateful.go
@@ -1,0 +1,141 @@
+package etcd
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/cybozu-go/log"
+)
+
+const (
+	lastRevFile = "lastrev"
+)
+
+func (d *driver) loadLastRev() int64 {
+	p := filepath.Join(d.dataDir, lastRevFile)
+	f, err := os.Open(p)
+	if err != nil {
+		log.Warn("failed to open lastrev file", map[string]interface{}{
+			log.FnError: err,
+		})
+		os.Remove(p)
+		return 0
+	}
+	defer f.Close()
+
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		log.Warn("failed to read lastrev file", map[string]interface{}{
+			log.FnError: err,
+		})
+		os.Remove(p)
+		return 0
+	}
+
+	rev, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		log.Warn("invalid lastrev file", map[string]interface{}{
+			log.FnError: err,
+		})
+		os.Remove(p)
+		return 0
+	}
+
+	return rev
+}
+
+func (d *driver) saveLastRev(rev int64) error {
+	p := filepath.Join(d.dataDir, lastRevFile)
+	f, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(strconv.FormatInt(rev, 10))
+	return err
+}
+
+func (d *driver) initStateful(ctx context.Context) (int64, error) {
+	// obtain the current revision.
+	resp, err := d.client.Get(ctx, "/")
+	if err != nil {
+		return 0, err
+	}
+	rev := resp.Header.Revision
+
+	err = d.initAssets(ctx, rev)
+	if err != nil {
+		return 0, err
+	}
+
+	return rev, nil
+}
+
+// startStatefulWatcher is a goroutine to begin watching for etcd events.
+//
+// This goroutine keeps the last seen revision in the data directory
+// to resume watching between restarts.  All events will be dispatched
+// to ch.
+func (d *driver) startStatefulWatcher(ctx context.Context, ch chan<- EventPool) error {
+	defer close(ch)
+
+RETRY:
+	rev := d.loadLastRev()
+	if rev == 0 {
+		log.Info("initialize stateful watching", nil)
+
+		var err error
+		rev, err = d.initStateful(ctx)
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Info("resume stateful watching", map[string]interface{}{
+			"rev": rev,
+		})
+	}
+
+	rch := d.client.Watch(ctx, KeyAssets,
+		clientv3.WithPrefix(),
+		clientv3.WithPrevKV(),
+		clientv3.WithRev(rev+1),
+		clientv3.WithCreatedNotify(),
+	)
+	var ep EventPool
+
+	for resp := range rch {
+		if resp.CompactRevision != 0 {
+			log.Warn("database has been compacted; re-initializing", map[string]interface{}{
+				"compactedrev": resp.CompactRevision,
+			})
+			d.saveLastRev(0)
+
+			// the watch will be canceled by the server as described in:
+			// https://godoc.org/github.com/coreos/etcd/clientv3#Watcher
+			for range rch {
+			}
+			goto RETRY
+		}
+
+		ep.Rev = resp.Header.Revision
+		ep.Events = append(ep.Events, resp.Events...)
+
+		if len(ep.Events) == 0 {
+			continue
+		}
+
+		select {
+		case ch <- ep:
+			ep.Events = nil
+		default:
+			// events are pooled
+		}
+	}
+
+	return nil
+}

--- a/models/etcd/watch_stateful.go
+++ b/models/etcd/watch_stateful.go
@@ -11,12 +11,8 @@ import (
 	"github.com/cybozu-go/log"
 )
 
-const (
-	lastRevFile = "lastrev"
-)
-
 func (d *driver) loadLastRev() int64 {
-	p := filepath.Join(d.dataDir, lastRevFile)
+	p := filepath.Join(d.dataDir, LastRevFile)
 	f, err := os.Open(p)
 	if err != nil {
 		log.Warn("failed to open lastrev file", map[string]interface{}{
@@ -49,7 +45,7 @@ func (d *driver) loadLastRev() int64 {
 }
 
 func (d *driver) saveLastRev(rev int64) error {
-	p := filepath.Join(d.dataDir, lastRevFile)
+	p := filepath.Join(d.dataDir, LastRevFile)
 	f, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0644)
 	if err != nil {
 		return err

--- a/models/etcd/watch_stateless.go
+++ b/models/etcd/watch_stateless.go
@@ -47,7 +47,7 @@ func (d *driver) initDHCPConfig(ctx context.Context) error {
 	return nil
 }
 
-func (d *driver) init(ctx context.Context, ch chan<- struct{}) (int64, error) {
+func (d *driver) initStateless(ctx context.Context, ch chan<- struct{}) (int64, error) {
 	defer func() {
 		// notify the caller of the readiness
 		ch <- struct{}{}
@@ -78,8 +78,12 @@ func (d *driver) init(ctx context.Context, ch chan<- struct{}) (int64, error) {
 	return rev, nil
 }
 
-func (d *driver) startWatching(ctx context.Context, ch, indexCh chan<- struct{}) error {
-	rev, err := d.init(ctx, ch)
+// startStatelessWatcher is a goroutine to begin watching for etcd events.
+//
+// This goroutine does not keep states between restarts; i.e. it loads
+// the up-to-date database entries in memory and keeps updating them.
+func (d *driver) startStatelessWatcher(ctx context.Context, ch, indexCh chan<- struct{}) error {
+	rev, err := d.initStateless(ctx, ch)
 	if err != nil {
 		return err
 	}

--- a/models/mock/asset.go
+++ b/models/mock/asset.go
@@ -67,7 +67,7 @@ func (d *assetDriver) Put(ctx context.Context, name, contentType string,
 }
 
 func (d *assetDriver) Get(ctx context.Context, name string,
-	f func(modtime time.Time, content io.ReadSeeker)) error {
+	f func(modtime time.Time, contentType string, content io.ReadSeeker)) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -76,7 +76,7 @@ func (d *assetDriver) Get(ctx context.Context, name string,
 		return sabakan.ErrNotFound
 	}
 
-	f(asset.Date, bytes.NewReader(d.data[name]))
+	f(asset.Date, asset.ContentType, bytes.NewReader(d.data[name]))
 
 	return nil
 }

--- a/models/mock/asset.go
+++ b/models/mock/asset.go
@@ -1,0 +1,165 @@
+package mock
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/cybozu-go/sabakan"
+)
+
+type assetDriver struct {
+	mu     sync.Mutex
+	assets map[string]*sabakan.Asset
+	data   map[string][]byte
+	lastID int
+}
+
+func newAssetDriver() *assetDriver {
+	return &assetDriver{
+		assets: make(map[string]*sabakan.Asset),
+		data:   make(map[string][]byte),
+	}
+}
+
+func (d *assetDriver) GetIndex(ctx context.Context) ([]string, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	ret := make([]string, 0, len(d.assets))
+	for k := range d.assets {
+		ret = append(ret, k)
+	}
+	sort.Strings(ret)
+	return ret, nil
+}
+
+func (d *assetDriver) GetInfo(ctx context.Context, name string) (*sabakan.Asset, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	asset, ok := d.assets[name]
+	if !ok {
+		return nil, sabakan.ErrNotFound
+	}
+
+	return asset, nil
+}
+
+func (d *assetDriver) Put(ctx context.Context, name, contentType string,
+	r io.Reader) (*sabakan.AssetStatus, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	asset, ok := d.assets[name]
+	if ok {
+		return d.updateAsset(ctx, asset, contentType, r)
+	}
+
+	return d.newAsset(ctx, name, contentType, r)
+}
+
+func (d *assetDriver) Get(ctx context.Context, name string,
+	f func(modtime time.Time, content io.ReadSeeker)) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	asset, ok := d.assets[name]
+	if !ok {
+		return sabakan.ErrNotFound
+	}
+
+	f(asset.Date, bytes.NewReader(d.data[name]))
+
+	return nil
+}
+
+func (d *assetDriver) Delete(ctx context.Context, name string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	_, ok := d.assets[name]
+	if !ok {
+		return sabakan.ErrNotFound
+	}
+
+	delete(d.assets, name)
+	delete(d.data, name)
+
+	return nil
+}
+
+func (d *assetDriver) newAsset(ctx context.Context, name, contentType string,
+	r io.Reader) (*sabakan.AssetStatus, error) {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	d.lastID++
+	id := d.lastID
+
+	h := sha256.New()
+	h.Write(data)
+	sum := hex.EncodeToString(h.Sum(nil))
+
+	asset := &sabakan.Asset{
+		Name:        name,
+		ID:          id,
+		ContentType: contentType,
+		Date:        time.Now().UTC(),
+		Sha256:      sum,
+		URLs:        nil,
+		Version:     1,
+		Exists:      true,
+	}
+
+	d.assets[name] = asset
+	d.data[name] = data
+
+	status := &sabakan.AssetStatus{
+		Status:  http.StatusCreated,
+		Version: 1,
+		ID:      id,
+	}
+
+	return status, nil
+}
+
+func (d *assetDriver) updateAsset(ctx context.Context, asset *sabakan.Asset,
+	contentType string, r io.Reader) (*sabakan.AssetStatus, error) {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	d.lastID++
+	id := d.lastID
+
+	h := sha256.New()
+	h.Write(data)
+	sum := hex.EncodeToString(h.Sum(nil))
+
+	asset.ID = id
+	asset.ContentType = contentType
+	asset.Date = time.Now().UTC()
+	asset.Sha256 = sum
+	asset.Version++
+
+	d.data[asset.Name] = data
+
+	status := &sabakan.AssetStatus{
+		Status:  http.StatusOK,
+		Version: asset.Version,
+		ID:      id,
+	}
+
+	return status, nil
+}

--- a/models/mock/driver.go
+++ b/models/mock/driver.go
@@ -34,6 +34,7 @@ func NewModel() sabakan.Model {
 		IPAM:     ipamDriver{d},
 		DHCP:     dhcpDriver{d},
 		Image:    newImageDriver(),
+		Asset:    newAssetDriver(),
 		Ignition: d,
 	}
 }

--- a/web/apierror.go
+++ b/web/apierror.go
@@ -34,9 +34,11 @@ func BadRequest(reason string) APIError {
 
 // Common API errors
 var (
-	APIErrBadRequest = APIError{http.StatusBadRequest, "invalid request", nil}
-	APIErrForbidden  = APIError{http.StatusForbidden, "forbidden", nil}
-	APIErrNotFound   = APIError{http.StatusNotFound, "requested resource is not found", nil}
-	APIErrBadMethod  = APIError{http.StatusMethodNotAllowed, "method not allowed", nil}
-	APIErrConflict   = APIError{http.StatusConflict, "conflicted", nil}
+	APIErrBadRequest     = APIError{http.StatusBadRequest, "invalid request", nil}
+	APIErrForbidden      = APIError{http.StatusForbidden, "forbidden", nil}
+	APIErrNotFound       = APIError{http.StatusNotFound, "requested resource is not found", nil}
+	APIErrBadMethod      = APIError{http.StatusMethodNotAllowed, "method not allowed", nil}
+	APIErrConflict       = APIError{http.StatusConflict, "conflicted", nil}
+	APIErrLengthRequired = APIError{http.StatusLengthRequired, "content-length is required", nil}
+	APIErrTooLargeAsset  = APIError{http.StatusRequestEntityTooLarge, "too large asset", nil}
 )

--- a/web/asset.go
+++ b/web/asset.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cybozu-go/sabakan"
+)
+
+const (
+	maxAssetSize = 2 << 30
+)
+
+func (s Server) handleAssets(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/api/v1/assets" {
+		s.handleAssetsIndex(w, r)
+		return
+	}
+
+	params := strings.Split(r.URL.Path[len("/api/v1/assets/"):], "/")
+	name := params[0]
+
+	switch r.Method {
+	case "GET", "HEAD":
+		switch len(params) {
+		case 1:
+			s.handleAssetsGet(w, r, name)
+			return
+		case 2:
+			if params[1] == "meta" {
+				s.handleAssetsInfo(w, r, name)
+				return
+			}
+		}
+		renderError(r.Context(), w, APIErrBadRequest)
+	case "PUT":
+		s.handleAssetsPut(w, r, name)
+	case "DELETE":
+		s.handleAssetsDelete(w, r, name)
+	default:
+		renderError(r.Context(), w, APIErrBadMethod)
+	}
+}
+
+func (s Server) handleAssetsIndex(w http.ResponseWriter, r *http.Request) {
+	index, err := s.Model.Asset.GetIndex(r.Context())
+	if err != nil {
+		renderError(r.Context(), w, InternalServerError(err))
+		return
+	}
+
+	renderJSON(w, index, http.StatusOK)
+}
+
+func (s Server) handleAssetsGet(w http.ResponseWriter, r *http.Request, name string) {
+	f := func(modtime time.Time, contentType string, content io.ReadSeeker) {
+		w.Header().Set("content-type", contentType)
+		http.ServeContent(w, r, name, modtime, content)
+	}
+	err := s.Model.Asset.Get(r.Context(), name, f)
+	if err == sabakan.ErrNotFound {
+		renderError(r.Context(), w, APIErrNotFound)
+		return
+	}
+	if err != nil {
+		renderError(r.Context(), w, InternalServerError(err))
+	}
+}
+
+func (s Server) handleAssetsInfo(w http.ResponseWriter, r *http.Request, name string) {
+	asset, err := s.Model.Asset.GetInfo(r.Context(), name)
+	if err == sabakan.ErrNotFound {
+		renderError(r.Context(), w, APIErrNotFound)
+		return
+	}
+	if err != nil {
+		renderError(r.Context(), w, InternalServerError(err))
+		return
+	}
+
+	renderJSON(w, asset, http.StatusOK)
+}
+
+func (s Server) handleAssetsPut(w http.ResponseWriter, r *http.Request, name string) {
+	contentType := r.Header.Get("content-type")
+	if len(contentType) == 0 {
+		renderError(r.Context(), w, APIErrBadRequest)
+		return
+	}
+	if r.ContentLength < 0 {
+		renderError(r.Context(), w, APIErrLengthRequired)
+		return
+	}
+	if r.ContentLength > maxAssetSize {
+		renderError(r.Context(), w, APIErrTooLargeAsset)
+		return
+	}
+	status, err := s.Model.Asset.Put(r.Context(), name, contentType, r.Body)
+	if err != nil {
+		renderError(r.Context(), w, InternalServerError(err))
+		return
+	}
+	renderJSON(w, status, status.Status)
+}
+
+func (s Server) handleAssetsDelete(w http.ResponseWriter, r *http.Request, name string) {
+	err := s.Model.Asset.Delete(r.Context(), name)
+	if err == sabakan.ErrNotFound {
+		renderError(r.Context(), w, APIErrNotFound)
+		return
+	}
+	if err != nil {
+		renderError(r.Context(), w, InternalServerError(err))
+	}
+}

--- a/web/asset.go
+++ b/web/asset.go
@@ -111,7 +111,8 @@ func (s Server) handleAssetsPut(w http.ResponseWriter, r *http.Request, name str
 		return
 	}
 
-	status, err := s.Model.Asset.Put(r.Context(), name, contentType, r.Body)
+	csum := r.Header.Get("X-Sabakan-Asset-SHA256")
+	status, err := s.Model.Asset.Put(r.Context(), name, contentType, csum, r.Body)
 	if err == sabakan.ErrConflicted {
 		renderError(r.Context(), w, APIErrConflict)
 		return

--- a/web/asset.go
+++ b/web/asset.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"encoding/hex"
 	"io"
 	"net/http"
 	"strconv"
@@ -111,7 +112,16 @@ func (s Server) handleAssetsPut(w http.ResponseWriter, r *http.Request, name str
 		return
 	}
 
-	csum := r.Header.Get("X-Sabakan-Asset-SHA256")
+	sum := r.Header.Get("X-Sabakan-Asset-SHA256")
+	var csum []byte
+	if len(sum) > 0 {
+		c, err := hex.DecodeString(sum)
+		if err != nil {
+			renderError(r.Context(), w, BadRequest("bad checksum: "+err.Error()))
+			return
+		}
+		csum = c
+	}
 	status, err := s.Model.Asset.Put(r.Context(), name, contentType, csum, r.Body)
 	if err == sabakan.ErrConflicted {
 		renderError(r.Context(), w, APIErrConflict)

--- a/web/asset_test.go
+++ b/web/asset_test.go
@@ -40,15 +40,15 @@ func testHandleAssetsGetIndex(t *testing.T) {
 		t.Error("len(data) != 0:", len(data))
 	}
 
-	_, err = m.Asset.Put(context.Background(), "foo", "text/plain", "", strings.NewReader("bar"))
+	_, err = m.Asset.Put(context.Background(), "foo", "text/plain", nil, strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = m.Asset.Put(context.Background(), "abc", "text/plain", "", strings.NewReader("bar"))
+	_, err = m.Asset.Put(context.Background(), "abc", "text/plain", nil, strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = m.Asset.Put(context.Background(), "xyz", "text/plain", "", strings.NewReader("bar"))
+	_, err = m.Asset.Put(context.Background(), "xyz", "text/plain", nil, strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,7 @@ func testHandleAssetsGetInfo(t *testing.T) {
 		t.Fatal("resp.StatusCode != http.StatusNotFound:", resp.StatusCode)
 	}
 
-	_, err := m.Asset.Put(context.Background(), "foo", "text/plain", "", strings.NewReader("bar"))
+	_, err := m.Asset.Put(context.Background(), "foo", "text/plain", nil, strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func testHandleAssetsGet(t *testing.T) {
 		t.Fatal("resp.StatusCode != http.StatusNotFound:", resp.StatusCode)
 	}
 
-	_, err := m.Asset.Put(context.Background(), "foo", "text/plain", "", strings.NewReader("bar"))
+	_, err := m.Asset.Put(context.Background(), "foo", "text/plain", nil, strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +252,7 @@ func testHandleAssetsPut(t *testing.T) {
 	r = httptest.NewRequest("PUT", "/api/v1/assets/foo", strings.NewReader("bar"))
 	r.Header.Set("content-length", "3")
 	r.Header.Set("content-type", "text/plain")
-	r.Header.Set("X-Sabakan-Asset-SHA256", "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9")
+	r.Header.Set("X-Sabakan-Asset-SHA256", "FCDE2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9")
 	handler.ServeHTTP(w, r)
 
 	resp = w.Result()
@@ -289,7 +289,7 @@ func testHandleAssetsDelete(t *testing.T) {
 		t.Fatal("resp.StatusCode != http.StatusNotFound:", resp.StatusCode)
 	}
 
-	_, err := m.Asset.Put(context.Background(), "foo", "text/plain", "", strings.NewReader("bar"))
+	_, err := m.Asset.Put(context.Background(), "foo", "text/plain", nil, strings.NewReader("bar"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/asset_test.go
+++ b/web/asset_test.go
@@ -155,6 +155,12 @@ func testHandleAssetsGet(t *testing.T) {
 	if resp.Header.Get("content-type") != "text/plain" {
 		t.Error("content-type != text/plain", resp.Header.Get("content-type"))
 	}
+	if len(resp.Header.Get("X-Sabakan-Asset-ID")) == 0 {
+		t.Error("X-Sabakan-Asset-ID is not set")
+	}
+	if resp.Header.Get("X-Sabakan-Asset-SHA256") != "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9" {
+		t.Error("X-Sabakan-Asset-SHA256 is not valid:", resp.Header.Get("X-Sabakan-Asset-SHA256"))
+	}
 }
 
 func testHandleAssetsPut(t *testing.T) {

--- a/web/asset_test.go
+++ b/web/asset_test.go
@@ -1,0 +1,287 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cybozu-go/sabakan"
+	"github.com/cybozu-go/sabakan/models/mock"
+)
+
+func testHandleAssetsGetIndex(t *testing.T) {
+	t.Parallel()
+
+	m := mock.NewModel()
+	handler := newTestServer(m)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/assets", nil)
+	handler.ServeHTTP(w, r)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("resp.StatusCode != http.StatusOK:", resp.StatusCode)
+	}
+
+	var data []string
+	err := json.NewDecoder(resp.Body).Decode(&data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 0 {
+		t.Error("len(data) != 0:", len(data))
+	}
+
+	_, err = m.Asset.Put(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = m.Asset.Put(context.Background(), "abc", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = m.Asset.Put(context.Background(), "xyz", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/assets", nil)
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("resp.StatusCode != http.StatusOK:", resp.StatusCode)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(data, []string{"abc", "foo", "xyz"}) {
+		t.Error("data is not valid:", data)
+	}
+}
+
+func testHandleAssetsGetInfo(t *testing.T) {
+	t.Parallel()
+
+	m := mock.NewModel()
+	handler := newTestServer(m)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/assets/foo/meta", nil)
+	handler.ServeHTTP(w, r)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatal("resp.StatusCode != http.StatusNotFound:", resp.StatusCode)
+	}
+
+	_, err := m.Asset.Put(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/assets/foo/meta", nil)
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("resp.StatusCode != http.StatusOK:", resp.StatusCode)
+	}
+
+	var data sabakan.Asset
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data.Name != "foo" {
+		t.Error("data.Name != foo:", data.Name)
+	}
+	if data.ContentType != "text/plain" {
+		t.Error("data.ContentType != text/plain:", data.ContentType)
+	}
+	if data.Sha256 != "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9" {
+		t.Error("data.Sha256 is not valid:", data.Sha256)
+	}
+}
+
+func testHandleAssetsGet(t *testing.T) {
+	t.Parallel()
+
+	m := mock.NewModel()
+	handler := newTestServer(m)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/assets/foo", nil)
+	handler.ServeHTTP(w, r)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatal("resp.StatusCode != http.StatusNotFound:", resp.StatusCode)
+	}
+
+	_, err := m.Asset.Put(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/assets/foo", nil)
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("resp.StatusCode != http.StatusOK:", resp.StatusCode)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "bar" {
+		t.Error("string(data) != bar", string(data))
+	}
+	if resp.Header.Get("content-type") != "text/plain" {
+		t.Error("content-type != text/plain", resp.Header.Get("content-type"))
+	}
+}
+
+func testHandleAssetsPut(t *testing.T) {
+	t.Parallel()
+	m := mock.NewModel()
+	handler := newTestServer(m)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("PUT", "/api/v1/assets/foo", strings.NewReader("bar"))
+	r.Header.Set("content-length", "3")
+	r.Header.Set("content-type", "text/plain")
+	handler.ServeHTTP(w, r)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatal("resp.StatusCode != http.StatusCreated:", resp.StatusCode)
+	}
+	var status sabakan.AssetStatus
+	err := json.NewDecoder(resp.Body).Decode(&status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Status != http.StatusCreated {
+		t.Error("status.Status != http.StatusCreated:", status.Status)
+	}
+	if status.Version != 1 {
+		t.Error("status.Version != 1:", status.Version)
+	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("PUT", "/api/v1/assets/foo", strings.NewReader("bar"))
+	r.Header.Set("content-length", "3")
+	r.Header.Set("content-type", "text/plain")
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("resp.StatusCode != http.StatusOK:", resp.StatusCode)
+	}
+	err = json.NewDecoder(resp.Body).Decode(&status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Status != http.StatusOK {
+		t.Error("status.Status != httpStatusOK:", status.Status)
+	}
+	if status.Version != 2 {
+		t.Error("status.Version != 2:", status.Version)
+	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("PUT", "/api/v1/assets/foo", strings.NewReader("bar"))
+	r.Header.Set("content-length", "3")
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Error("resp.StatusCode != http.StatusBadRequest:", resp.StatusCode)
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		pw.Write([]byte("bar"))
+		pw.Close()
+	}()
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("PUT", "/api/v1/assets/foo", pr)
+	r.Header.Set("content-type", "text/plain")
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusLengthRequired {
+		t.Fatal("resp.StatusCode != http.StatusLengthRequired:", resp.StatusCode)
+	}
+
+	pr2, pw2 := io.Pipe()
+	go func() {
+		pw2.Write([]byte("bar"))
+		pw2.Close()
+	}()
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("PUT", "/api/v1/assets/foo", pr2)
+	r.Header.Set("content-length", strconv.FormatInt(5<<30, 10))
+	r.ContentLength = 5 << 30
+	r.Header.Set("content-type", "text/plain")
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatal("resp.StatusCode != http.StatusRequestEntityTooLarge:", resp.StatusCode)
+	}
+}
+
+func testHandleAssetsDelete(t *testing.T) {
+	t.Parallel()
+
+	m := mock.NewModel()
+	handler := newTestServer(m)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("DELETE", "/api/v1/assets/foo", nil)
+	handler.ServeHTTP(w, r)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatal("resp.StatusCode != http.StatusNotFound:", resp.StatusCode)
+	}
+
+	_, err := m.Asset.Put(context.Background(), "foo", "text/plain", strings.NewReader("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("DELETE", "/api/v1/assets/foo", nil)
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("resp.StatusCode != http.StatusOK:", resp.StatusCode)
+	}
+}
+
+func TestHandleAssets(t *testing.T) {
+	t.Run("GetIndex", testHandleAssetsGetIndex)
+	t.Run("GetInfo", testHandleAssetsGetInfo)
+	t.Run("Get", testHandleAssetsGet)
+	t.Run("Put", testHandleAssetsPut)
+	t.Run("Delete", testHandleAssetsDelete)
+}

--- a/web/asset_test.go
+++ b/web/asset_test.go
@@ -180,9 +180,6 @@ func testHandleAssetsPut(t *testing.T) {
 	if status.Status != http.StatusCreated {
 		t.Error("status.Status != http.StatusCreated:", status.Status)
 	}
-	if status.Version != 1 {
-		t.Error("status.Version != 1:", status.Version)
-	}
 
 	w = httptest.NewRecorder()
 	r = httptest.NewRequest("PUT", "/api/v1/assets/foo", strings.NewReader("bar"))
@@ -200,9 +197,6 @@ func testHandleAssetsPut(t *testing.T) {
 	}
 	if status.Status != http.StatusOK {
 		t.Error("status.Status != httpStatusOK:", status.Status)
-	}
-	if status.Version != 2 {
-		t.Error("status.Version != 2:", status.Version)
 	}
 
 	w = httptest.NewRecorder()

--- a/web/server.go
+++ b/web/server.go
@@ -36,14 +36,8 @@ func (s Server) handleAPIV1(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch {
-	case p == "config/dhcp":
-		s.handleConfigDHCP(w, r)
-		return
-	case p == "config/ipam":
-		s.handleConfigIPAM(w, r)
-		return
-	case strings.HasPrefix(p, "crypts/"):
-		s.handleCrypts(w, r)
+	case p == "assets" || strings.HasPrefix(p, "assets/"):
+		s.handleAssets(w, r)
 		return
 	case p == "boot/ipxe.efi":
 		http.ServeFile(w, r, s.IPXEFirmware)
@@ -54,14 +48,23 @@ func (s Server) handleAPIV1(w http.ResponseWriter, r *http.Request) {
 	case strings.HasPrefix(p, "boot/ignitions/"):
 		s.handleIgnitions(w, r)
 		return
+	case p == "config/dhcp":
+		s.handleConfigDHCP(w, r)
+		return
+	case p == "config/ipam":
+		s.handleConfigIPAM(w, r)
+		return
+	case strings.HasPrefix(p, "crypts/"):
+		s.handleCrypts(w, r)
+		return
 	case strings.HasPrefix(p, "ignitions/"):
 		s.handleIgnitionTemplates(w, r)
 		return
-	case strings.HasPrefix(p, "machines"):
-		s.handleMachines(w, r)
-		return
 	case p == "images/coreos" || strings.HasPrefix(p, "images/coreos/"):
 		s.handleImages(w, r)
+		return
+	case strings.HasPrefix(p, "machines"):
+		s.handleMachines(w, r)
 		return
 	}
 


### PR DESCRIPTION
This series of commits implements asset management functions.

Assets are files served by sabakan servers.  Netboot clients can download
assets from sabakan after boot to configure themselves further.

Assets are distributed automatically among sabakan servers.
After an operator uploads an asset to a sabakan server, the other server
pulls it to have local copies of the asset.  etcd keeps only meta data of
assets.