### PR TITLE
Fix not matched between implements and documents

### DIFF
--- a/cmd/sabactl/machines.go
+++ b/cmd/sabactl/machines.go
@@ -40,6 +40,7 @@ var machinesGetQuery = map[string]string{
 	"serial":     "Serial name",
 	"datacenter": "Datacenter name",
 	"rack":       "Rack name",
+	"role":       "Role name",
 	"product":    "Product name (e.g. 'R630')",
 	"ipv4":       "IPv4 address",
 	"ipv6":       "IPv6 address",

--- a/cmd/sabactl/sabactl_completion.bash
+++ b/cmd/sabactl/sabactl_completion.bash
@@ -1,5 +1,5 @@
 _sabactl_help_complete() {
-  COMPREPLY=( $(compgen -W "commands dhcp flags help ignitions images ipam machines" -- "$cur") )
+  COMPREPLY=( $(compgen -W "commands dhcp flags help ignitions images assets ipam machines" -- "$cur") )
 }
 
 _sabactl_dhcp_complete() {
@@ -43,6 +43,18 @@ _sabactl_images_complete() {
   fi
 }
 
+_sabactl_assets_complete() {
+    # sabactl assets index
+    # sabactl assets delete NAME
+    # sabactl assets info NAME
+    # sabactl assets upload NAME FILE
+    if [[ "$cword" == 1 || "$cword" == 2 ]]; then
+        COMPREPLY=( $(compgen -W "index delete info upload" -- "$cur") )
+    elif [[ "$cword" == 4  && "${words[2]}" == "upload" ]]; then
+        COMPREPLY=( $(compgen -o filenames -A file -- "$cur") )
+    fi
+}
+
 _sabactl_ipam_complete() {
   # sabactl ipam get
   # sabactl ipam set -f FILE
@@ -84,6 +96,7 @@ _sabactl() {
     dhcp) _sabactl_dhcp_complete ;;
     ignitions) _sabactl_ignitions_complete ;;
     images) _sabactl_images_complete ;;
+    assets) _sabactl_assets_complete ;;
     ipam) _sabactl_ipam_complete ;;
     machines) _sabactl_machines_complete ;;
   esac

--- a/docs/api.md
+++ b/docs/api.md
@@ -210,7 +210,6 @@ Query                      | Description
 `datacenter=<datacenter>`  | The data center name where the machine is in
 `rack=<rack>`              | The rack number where the machine is in
 `role=<role>`              | The role of the machine
-`index-in-rack=<rack>`     | The unique index number of the machine. It is not relevant with the physical location
 `product=<product>`        | The product name of the machine(e.g. `R630`)
 `ipv4=<ip address>`        | IPv4 address
 `ipv6=<ip address>`        | IPv6 address

--- a/docs/sabactl.md
+++ b/docs/sabactl.md
@@ -73,7 +73,16 @@ Detailed specification of the input JSON file is same as that of the [`POST /api
 Show machines filtered by query parameters.
 
 ```console
-$ sabactl machines get [--serial <serial>] [--state <state>] [--datacenter <datacenter>] [--rack <rack>] [--product <product>] [--ipv4 <ip address>] [--ipv6 <ip address>] [--bmc-type <BMC type>]
+$ sabactl machines get \
+    [--serial <serial>] \
+    [--datacenter <datacenter>] \
+    [--rack <rack>] \
+    [--role <role>] \
+    [--product <product>] \
+    [--ipv4 <ip address>] \
+    [--ipv6 <ip address>] \
+    [--bmc-type <BMC type>] \
+    [--state <state>]
 ```
 
 Detailed specification of the query parameters and the output JSON content is same as those of the [`GET /api/v1/machines` API](api.md#getmachines).


### PR DESCRIPTION
- Add --role option in sabactl machines get.
- Remove index-in-rack from api.md because of no implementation.
- Order sabactl machines get option in sabactl.md.