### PR TITLE
Audit logging framework

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -1,0 +1,68 @@
+package sabakan
+
+import (
+	"context"
+	"time"
+)
+
+// AuditCategory is the type of audit categories.
+type AuditCategory string
+
+// Audit categories.
+const (
+	AuditAssets   = AuditCategory("assets")
+	AuditCrypts   = AuditCategory("crypts")
+	AuditDHCP     = AuditCategory("dhcp")
+	AuditIgnition = AuditCategory("ignition")
+	AuditImage    = AuditCategory("image")
+	AuditIPAM     = AuditCategory("ipam")
+	AuditIPXE     = AuditCategory("ipxe")
+	AuditMachines = AuditCategory("machines")
+)
+
+// AuditLog represents an audit log entry.
+type AuditLog struct {
+	Timestamp time.Time     `json:"ts"`
+	Revision  int64         `json:"rev,string"`
+	User      string        `json:"user"`
+	IP        string        `json:"ip"`
+	Host      string        `json:"host"`
+	Category  AuditCategory `json:"category"`
+	Instance  string        `json:"instance"`
+	Action    string        `json:"action"`
+	Detail    string        `json:"detail"`
+}
+
+// AuditContextKey is the type of context keys for audit.
+type AuditContextKey string
+
+// Audit context keys.  Values must be string.
+const (
+	AuditKeyUser = AuditContextKey("user")
+	AuditKeyIP   = AuditContextKey("ip")
+	AuditKeyHost = AuditContextKey("host")
+)
+
+// NewAuditLog creates an audit log entry and initializes it.
+func NewAuditLog(ctx context.Context, ts time.Time, rev int64, cat AuditCategory,
+	instance, action, detail string) *AuditLog {
+
+	a := new(AuditLog)
+	a.Timestamp = ts.UTC()
+	a.Revision = rev
+	if v := ctx.Value(AuditKeyUser); v != nil {
+		a.User = v.(string)
+	}
+	if v := ctx.Value(AuditKeyIP); v != nil {
+		a.IP = v.(string)
+	}
+	if v := ctx.Value(AuditKeyHost); v != nil {
+		a.Host = v.(string)
+	}
+	a.Category = cat
+	a.Instance = instance
+	a.Action = action
+	a.Detail = detail
+
+	return a
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,7 @@ REST API
 * [PUT /api/v1/crypts](#putcrypts)
 * [GET /api/v1/crypts](#getcrypts)
 * [DELETE /api/v1/crypts](#deletecrypts)
+* [GET /api/v1/logs](#getlogs)
 
 ## Access control
 
@@ -727,3 +728,20 @@ Content-Length: 18
 - The machine is not found.
 
     HTTP status code: 404 Not Found
+
+## <a name="getlogs" />`GET /api/v1/logs`
+
+Retrieve logs as [JSONLines](http://jsonlines.org/).
+Each line represents an audit log entry as described in [audit log](audit.md).
+
+If no URL parameter is given, this returns all logs stored in etcd.
+Following parameters may be specified to limit the response:
+
+* `since=YYYYMMDD`: retrieve logs after `YYYYMMDD`.
+* `until=YYYYMMDD`: retrieve logs before `YYYYMMDD`.
+
+### Example:
+
+`GET /api/v1/logs?since=20180404&until=20180407` retrieves logs generated on
+2018-04-04, 2018-04-05, and 2018-04-06.  Note that the date specified for
+`until` is not included.

--- a/docs/api.md
+++ b/docs/api.md
@@ -735,10 +735,12 @@ Retrieve logs as [JSONLines](http://jsonlines.org/).
 Each line represents an audit log entry as described in [audit log](audit.md).
 
 If no URL parameter is given, this returns all logs stored in etcd.
-Following parameters may be specified to limit the response:
+Following parameters can be specified to limit the response:
 
 * `since=YYYYMMDD`: retrieve logs after `YYYYMMDD`.
 * `until=YYYYMMDD`: retrieve logs before `YYYYMMDD`.
+
+The dates are interpreted in UTC timezone.
 
 ### Example:
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,0 +1,34 @@
+Audit log
+=========
+
+Sabakan records important operations in etcd for audit.
+They can be viewed by `sabactl log` sub command.
+
+Log structure
+-------------
+
+Each operation log is structured to have following fields:
+
+Field      | Type   | Description
+---------- | ------ | -----------
+`ts`       | string | The timestamp of the event in [RFC3339][] format.
+`rev`      | string | etcd revision of the event.  This is a string-formatted integer.
+`user`     | string | UNIX user name who executed `sabactl`.
+`ip`       | string | IP address of the host that connected to `sabakan`.
+`host`     | string | Hostname where `sabakan` server did the operation.
+`category` | string | Operation category such as `machines`, `ipam`, `crypts`, etc.
+`instance` | string | ID of the object that was the target of the operation.
+`action`   | string | A short verb such as `delete` or `update`.
+`detail`   | string | A detailed explanation of the operation.
+
+Compaction
+----------
+
+Log entries are kept for 60 days in etcd.  Logs older than 60 days
+are automatically removed.  To keep them longer, administrators should
+export logs using `sabactl log`.
+
+Note that etcd is not designed to store large objects.  The default
+maximum database size is only 2 GiB.
+
+[RFC3339]: https://www.ietf.org/rfc/rfc3339.txt

--- a/docs/sabactl.md
+++ b/docs/sabactl.md
@@ -215,3 +215,16 @@ Delete a ignition template for a certain role.
 ```console
 $ sabactl ignitions delete <role> <id>
 ```
+
+`sabactl log [-json] [START_DATE] [END_DATE]`
+-------------------------------------
+
+Retrieve [audit logs](audit.md) and output them to stdout.
+
+If `-json` is given, each log entry will be displayed in JSON.
+
+If `START_DATE` is given, and `END_DATE` is *not* given, logs
+of `START_DATE` are retrieved.
+
+If `START_DATE` and `END_DATE` is given, logs between them are
+retrieved.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -105,14 +105,14 @@ $ etcdctl get "/sabakan/node-indices/0"
 [3, 4, 5]
 ```
 
-`<prefix>/audit/<YYYYMMDD>/<32 byte HEX string>`
+`<prefix>/audit/<YYYYMMDD>/<16-digit HEX string>`
 ------------------------------------------------
 
 Each entry of audit log is stored with this type of key.
 The value is JSON having fields defined in [audit log](audit.md).
 
 * `<YYYYMMDD>` is the date of the event.
-* `<32 byte HEX string>` is the hexadecimal representation of the event revision.
+* `<16-digit HEX string>` is the hexadecimal representation of the event revision.
 
 `<prefix>/audit`
 ----------------

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -104,3 +104,18 @@ The value is a list of assigned indices formatted in JSON.
 $ etcdctl get "/sabakan/node-indices/0"
 [3, 4, 5]
 ```
+
+`<prefix>/audit/<YYYYMMDD>/<32 byte HEX string>`
+------------------------------------------------
+
+Each entry of audit log is stored with this type of key.
+The value is JSON having fields defined in [audit log](audit.md).
+
+* `<YYYYMMDD>` is the date of the event.
+* `<32 byte HEX string>` is the hexadecimal representation of the event revision.
+
+`<prefix>/audit`
+----------------
+
+This key stores RFC3339-format timestamp to record the last compaction
+of audit logs.

--- a/model.go
+++ b/model.go
@@ -89,6 +89,11 @@ type IgnitionModel interface {
 	DeleteTemplate(ctx context.Context, role string, id string) error
 }
 
+// LogModel is an interface for audit logs.
+type LogModel interface {
+	Dump(ctx context.Context, since, until time.Time, w io.Writer) error
+}
+
 // Runner is an interface to run the underlying threads.
 //
 // The caller must pass a channel as follows.
@@ -114,4 +119,5 @@ type Model struct {
 	Image    ImageModel
 	Asset    AssetModel
 	Ignition IgnitionModel
+	Log      LogModel
 }

--- a/models/etcd/constants.go
+++ b/models/etcd/constants.go
@@ -1,5 +1,7 @@
 package etcd
 
+import "time"
+
 // Internal schema keys.
 const (
 	KeyCrypts      = "crypts/"
@@ -12,6 +14,8 @@ const (
 	KeyAssets      = "assets/"
 	KeyAssetsID    = "assets"
 	KeyIgnitions   = "ignitions/"
+	KeyAudit       = "audit/"
+	KeyAuditLastGC = "audit"
 )
 
 // MaxDeleted is the maximum number of deleted image IDs stored in etcd.
@@ -27,4 +31,12 @@ const (
 	maxJitterSeconds = 30
 	maxAssetURLs     = 10
 	maxImageURLs     = 10
+)
+
+// Log parameters
+const (
+	logRetentionDays      = 60
+	logCompactionTick     = 1 * time.Hour
+	logCompactionInterval = 23 * time.Hour
+	logPageSize           = 100
 )

--- a/models/etcd/driver.go
+++ b/models/etcd/driver.go
@@ -42,6 +42,7 @@ func NewModel(client *clientv3.Client, dataDir string, advertiseURL *url.URL) sa
 		DHCP:     dhcpDriver{d},
 		Image:    imageDriver{d},
 		Asset:    assetDriver{d},
+		Log:      logDriver{d},
 		Ignition: d,
 	}
 }
@@ -97,6 +98,9 @@ func (d *driver) Run(ctx context.Context, ch chan<- struct{}) error {
 	env.Go(func(ctx context.Context) error {
 		return d.startAssetUpdater(ctx, epCh)
 	})
+
+	// log compaction
+	env.Go(d.logCompactor)
 
 	env.Stop()
 

--- a/models/etcd/log.go
+++ b/models/etcd/log.go
@@ -1,0 +1,210 @@
+package etcd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/clientv3util"
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/sabakan"
+)
+
+func auditKey(t time.Time) string {
+	return KeyAudit + t.UTC().Format("20060102") + "/"
+}
+
+func (d *driver) addLog(ctx context.Context, ts time.Time, rev int64, cat sabakan.AuditCategory,
+	instance, action, detail string) {
+
+	a := sabakan.NewAuditLog(ctx, ts, rev, cat, instance, action, detail)
+	j, err := json.Marshal(a)
+	if err != nil { // unlikely
+		log.Error("etcd: addLog failed", map[string]interface{}{
+			log.FnError: err,
+			"category":  string(cat),
+			"instance":  instance,
+			"action":    action,
+		})
+		return
+	}
+
+	key := auditKey(ts) + fmt.Sprintf("%016x", uint64(rev))
+	_, err = d.client.Put(ctx, key, string(j))
+	if err == nil {
+		return
+	}
+
+	log.Error("etcd: addLog failed", map[string]interface{}{
+		log.FnError: err,
+		"category":  string(cat),
+		"instance":  instance,
+		"action":    action,
+	})
+}
+
+func (d *driver) logLastGCTime(ctx context.Context, nowData string) (t time.Time, rev int64, e error) {
+RETRY:
+	resp, err := d.client.Get(ctx, KeyAuditLastGC)
+	if err != nil {
+		e = err
+		return
+	}
+	if resp.Count == 0 {
+		_, err := d.client.Txn(ctx).
+			If(clientv3util.KeyMissing(KeyAuditLastGC)).
+			Then(clientv3.OpPut(KeyAuditLastGC, nowData)).
+			Commit()
+		if err != nil {
+			e = err
+			return
+		}
+		goto RETRY
+	}
+
+	err = json.Unmarshal(resp.Kvs[0].Value, &t)
+	if err != nil {
+		e = err
+		return
+	}
+
+	rev = resp.Kvs[0].ModRevision
+	return
+}
+
+func (d *driver) logCompact(ctx context.Context, now time.Time) error {
+	oldest := now.Add(time.Duration(-logRetentionDays) * 24 * time.Hour)
+	key := auditKey(oldest)
+
+	log.Info("log: compacting...", map[string]interface{}{
+		"key": key,
+	})
+
+	resp, err := d.client.Delete(ctx, KeyAudit, clientv3.WithRange(key))
+	if err != nil {
+		return err
+	}
+
+	log.Info("log: compacted", map[string]interface{}{
+		"deleted": resp.Deleted,
+	})
+
+	return nil
+}
+
+func (d *driver) logTryCompact(ctx context.Context, now time.Time) error {
+	j, err := json.Marshal(now)
+	if err != nil {
+		return err
+	}
+	nowData := string(j)
+
+	lastGC, rev, err := d.logLastGCTime(ctx, nowData)
+	if err != nil {
+		return err
+	}
+
+	if now.Sub(lastGC) < logCompactionInterval {
+		return nil
+	}
+
+	tresp, err := d.client.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(KeyAuditLastGC), "=", rev)).
+		Then(clientv3.OpPut(KeyAuditLastGC, nowData)).
+		Commit()
+	if err != nil {
+		return err
+	}
+	if !tresp.Succeeded {
+		return nil
+	}
+
+	return d.logCompact(ctx, now)
+}
+
+// logCompactor is a goroutine to compact logs periodically.
+func (d *driver) logCompactor(ctx context.Context) error {
+	ticker := time.NewTicker(logCompactionTick)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case now := <-ticker.C:
+			err := d.logTryCompact(ctx, now.UTC())
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (d *driver) logDump(ctx context.Context, since, until time.Time, w io.Writer) error {
+	bufw := bufio.NewWriterSize(w, 2048)
+
+	key := KeyAudit
+	endKey := clientv3.GetPrefixRangeEnd(KeyAudit)
+
+	if !since.IsZero() {
+		key = auditKey(since)
+	}
+	if !until.IsZero() {
+		endKey = auditKey(until)
+	}
+
+	// paginate for large number of logs
+
+	resp, err := d.client.Get(ctx, key,
+		clientv3.WithRange(endKey),
+		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
+		clientv3.WithLimit(logPageSize),
+	)
+	if err != nil {
+		return err
+	}
+	rev := resp.Header.Revision //  to retrieve following pages from the same revisoin.
+	kvs := resp.Kvs
+
+REDO:
+	for _, kv := range kvs {
+		_, err = bufw.Write(kv.Value)
+		if err != nil {
+			return err
+		}
+		err = bufw.WriteByte('\n')
+		if err != nil {
+			return err
+		}
+	}
+
+	if resp.More {
+		resp, err = d.client.Get(ctx, string(resp.Kvs[len(resp.Kvs)-1].Key),
+			clientv3.WithRange(endKey),
+			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
+			clientv3.WithLimit(logPageSize),
+			clientv3.WithRev(rev),
+		)
+		if err != nil {
+			return err
+		}
+
+		// ignore the first key
+		kvs = resp.Kvs[1:]
+		goto REDO
+	}
+
+	return bufw.Flush()
+}
+
+type logDriver struct {
+	*driver
+}
+
+func (d logDriver) Dump(ctx context.Context, since, until time.Time, w io.Writer) error {
+	return d.logDump(ctx, since, until, w)
+}

--- a/models/etcd/log_test.go
+++ b/models/etcd/log_test.go
@@ -1,0 +1,241 @@
+package etcd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/cybozu-go/sabakan"
+)
+
+func testLogAdd(t *testing.T) {
+	t.Parallel()
+
+	d, _ := testNewDriver(t)
+
+	ctx := context.Background()
+	ts := time.Date(2013, time.April, 5, 1, 2, 3, 4, time.UTC)
+	d.addLog(ctx, ts, 255, sabakan.AuditIPAM, "config", "put", "test")
+
+	key := "audit/20130405/00000000000000ff"
+	resp, err := d.client.Get(ctx, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Count == 0 {
+		t.Fatal("log entry not found at", key)
+	}
+
+	var a sabakan.AuditLog
+	err = json.Unmarshal(resp.Kvs[0].Value, &a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !a.Timestamp.Equal(ts) {
+		t.Error(a.Timestamp.String(), "!=", ts.String())
+	}
+}
+
+func testLogCompact(t *testing.T) {
+	t.Parallel()
+
+	d, _ := testNewDriver(t)
+	ctx := context.Background()
+
+	now := time.Date(2013, time.April, 5, 1, 2, 3, 4, time.UTC)
+	ts := now.Add(-61 * 24 * time.Hour)
+	for i := int64(0); i < 3; i++ {
+		d.addLog(ctx, ts, 100+i, sabakan.AuditIPAM, "config", "put", "test")
+		ts = ts.Add(24 * time.Hour)
+	}
+
+	countFunc := func() (int64, error) {
+		resp, err := d.client.Get(ctx, KeyAudit, clientv3.WithPrefix(), clientv3.WithCountOnly())
+		if err != nil {
+			return 0, err
+		}
+		return resp.Count, nil
+	}
+
+	count, err := countFunc()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 {
+		t.Error(`count != 3`, count)
+	}
+
+	err = d.logCompact(ctx, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count, err = countFunc()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Error(`count != 2`, count)
+	}
+
+	err = d.logCompact(ctx, now.Add(48*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	count, err = countFunc()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Error(`count != 0`, count)
+	}
+}
+
+func testLogTryCompact(t *testing.T) {
+	t.Parallel()
+
+	d, _ := testNewDriver(t)
+	ctx := context.Background()
+
+	now := time.Date(2013, time.April, 5, 1, 2, 3, 4, time.UTC)
+	ts := now.Add(-61 * 24 * time.Hour)
+	for i := int64(0); i < 3; i++ {
+		d.addLog(ctx, ts, 100+i, sabakan.AuditIPAM, "config", "put", "test")
+		ts = ts.Add(24 * time.Hour)
+	}
+
+	countFunc := func() (int64, error) {
+		resp, err := d.client.Get(ctx, KeyAudit, clientv3.WithPrefix(), clientv3.WithCountOnly())
+		if err != nil {
+			return 0, err
+		}
+		return resp.Count, nil
+	}
+
+	err := d.logTryCompact(ctx, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count, err := countFunc()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 {
+		t.Error(`count != 3`, count)
+	}
+
+	resp, err := d.client.Get(ctx, KeyAuditLastGC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Count == 0 {
+		t.Fatal(`resp.Count == 0`)
+	}
+	var lastGC time.Time
+	err = json.Unmarshal(resp.Kvs[0].Value, &lastGC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !lastGC.Equal(now) {
+		t.Error(`!lastGC.Equal(now)`, lastGC)
+	}
+
+	now = now.Add(24 * time.Hour)
+	err = d.logTryCompact(ctx, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count, err = countFunc()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Error(`count != 1`, count)
+	}
+}
+
+func testLogDump(t *testing.T) {
+	t.Parallel()
+
+	d, _ := testNewDriver(t)
+	ctx := context.Background()
+
+	begin := time.Date(2013, time.April, 5, 1, 2, 3, 4, time.UTC)
+	end := begin
+	for i := int64(0); i < 2*logPageSize; i++ {
+		d.addLog(ctx, end, 100+i, sabakan.AuditIPAM, "config", "put", "test")
+		end = end.Add(time.Hour)
+	}
+
+	buf := new(bytes.Buffer)
+	err := d.logDump(ctx, time.Time{}, time.Time{}, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := buf.Bytes()
+	count := bytes.Count(data, []byte("\n"))
+	if count != 2*logPageSize {
+		t.Error(`count != 2 * logPageSize`, count)
+	}
+
+	var a sabakan.AuditLog
+	err = json.Unmarshal(data[:bytes.IndexByte(data, '\n')], &a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Revision != 100 {
+		t.Error(`a.Revision != 100`, a.Revision)
+	}
+	err = json.Unmarshal(data[bytes.LastIndexByte(data[:len(data)-1], '\n'):], &a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Revision != 100+2*logPageSize-1 {
+		t.Error(`a.Revision != 100+2*logPageSize-1`, a.Revision)
+	}
+
+	buf.Reset()
+	err = d.logDump(ctx, time.Date(2013, time.April, 6, 0, 0, 0, 0, time.UTC), time.Time{}, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = buf.Bytes()
+	count = bytes.Count(data, []byte("\n"))
+	if count != 2*logPageSize-23 {
+		t.Error(`count != 2*logPageSize-23`, count)
+	}
+
+	buf.Reset()
+	err = d.logDump(ctx, time.Time{}, time.Date(2013, time.April, 6, 0, 0, 0, 0, time.UTC), buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = buf.Bytes()
+	count = bytes.Count(data, []byte("\n"))
+	if count != 23 {
+		t.Error(`count != 23`, count)
+	}
+
+	buf.Reset()
+	err = d.logDump(ctx,
+		time.Date(2013, time.April, 6, 0, 0, 0, 0, time.UTC),
+		time.Date(2013, time.April, 7, 0, 0, 0, 0, time.UTC),
+		buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = buf.Bytes()
+	count = bytes.Count(data, []byte("\n"))
+	if count != 24 {
+		t.Error(`count != 24`, count)
+	}
+}
+
+func TestLog(t *testing.T) {
+	t.Run("Add", testLogAdd)
+	t.Run("Compact", testLogCompact)
+	t.Run("TryCompact", testLogTryCompact)
+	t.Run("Dump", testLogDump)
+}

--- a/models/mock/driver.go
+++ b/models/mock/driver.go
@@ -14,6 +14,7 @@ type driver struct {
 	ipam     *sabakan.IPAMConfig
 	machines map[string]*sabakan.Machine
 	storage  map[string][]byte
+	log      *sabakan.AuditLog
 }
 
 // NewModel returns sabakan.Model
@@ -31,6 +32,7 @@ func NewModel() sabakan.Model {
 		Image:    newImageDriver(),
 		Asset:    newAssetDriver(),
 		Ignition: newIgnitionDriver(),
+		Log:      logDriver{d},
 	}
 }
 

--- a/models/mock/ipam.go
+++ b/models/mock/ipam.go
@@ -16,6 +16,8 @@ func (d *driver) putIPAMConfig(ctx context.Context, config *sabakan.IPAMConfig) 
 	}
 	copied := *config
 	d.ipam = &copied
+	d.log = sabakan.NewAuditLog(ctx, 1, sabakan.AuditIPAM, "config", "put", "test")
+
 	return nil
 }
 

--- a/models/mock/ipam.go
+++ b/models/mock/ipam.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"time"
 
 	"github.com/cybozu-go/sabakan"
 	"github.com/pkg/errors"
@@ -16,7 +17,8 @@ func (d *driver) putIPAMConfig(ctx context.Context, config *sabakan.IPAMConfig) 
 	}
 	copied := *config
 	d.ipam = &copied
-	d.log = sabakan.NewAuditLog(ctx, 1, sabakan.AuditIPAM, "config", "put", "test")
+	d.log = sabakan.NewAuditLog(ctx, time.Now().UTC(), 1, sabakan.AuditIPAM,
+		"config", "put", "test")
 
 	return nil
 }

--- a/models/mock/log.go
+++ b/models/mock/log.go
@@ -1,0 +1,16 @@
+package mock
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"time"
+)
+
+type logDriver struct {
+	*driver
+}
+
+func (d logDriver) Dump(ctx context.Context, since, until time.Time, w io.Writer) error {
+	return json.NewEncoder(w).Encode(d.driver.log)
+}

--- a/web/logs.go
+++ b/web/logs.go
@@ -1,0 +1,38 @@
+package web
+
+import (
+	"net/http"
+	"time"
+)
+
+func parseDate(v string) (time.Time, error) {
+	if len(v) == 0 {
+		return time.Time{}, nil
+	}
+
+	return time.Parse("20060102", v)
+}
+
+func (s Server) handleLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		renderError(r.Context(), w, APIErrBadMethod)
+		return
+	}
+
+	since, err := parseDate(r.FormValue("since"))
+	if err != nil {
+		renderError(r.Context(), w, BadRequest(err.Error()))
+		return
+	}
+	until, err := parseDate(r.FormValue("until"))
+	if err != nil {
+		renderError(r.Context(), w, BadRequest(err.Error()))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	err = s.Model.Log.Dump(r.Context(), since, until, w)
+	if err != nil {
+		renderError(r.Context(), w, InternalServerError(err))
+	}
+}

--- a/web/logs_test.go
+++ b/web/logs_test.go
@@ -1,0 +1,81 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cybozu-go/sabakan"
+	"github.com/cybozu-go/sabakan/models/mock"
+)
+
+func TestLogs(t *testing.T) {
+	t.Parallel()
+
+	m := mock.NewModel()
+	handler := newTestServer(m)
+
+	good := `
+{
+   "max-nodes-in-rack": 28,
+   "node-ipv4-pool": "10.69.0.0/20",
+   "node-ipv4-range-size": 6,
+   "node-ipv4-range-mask": 26,
+   "node-index-offset": 3,
+   "node-ip-per-node": 3,
+   "bmc-ipv4-pool": "10.72.16.0/20",
+   "bmc-ipv4-range-size": 5,
+   "bmc-ipv4-range-mask": 20
+}
+`
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("PUT", "/api/v1/config/ipam", strings.NewReader(good))
+	handler.ServeHTTP(w, r)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("resp.StatusCode != http.StatusOK")
+	}
+
+	r = httptest.NewRequest("GET", "/api/v1/logs", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("request failed with " + http.StatusText(resp.StatusCode))
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	a := new(sabakan.AuditLog)
+	err := dec.Decode(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Category != sabakan.AuditIPAM {
+		t.Error(`a.Category != sabakan.AuditIPAM`, a.Category)
+	}
+
+	if dec.More() {
+		t.Error(`should have no more JSON`)
+	}
+
+	r = httptest.NewRequest("GET", "/api/v1/logs?since=2018-04-04", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	resp = w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Error(`resp.StatusCode != http.StatusBadRequest`, resp.StatusCode)
+	}
+
+	r = httptest.NewRequest("GET", "/api/v1/logs?until=20190404", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Error(`resp.StatusCode != http.StatusOK`, resp.StatusCode)
+	}
+}

--- a/web/server.go
+++ b/web/server.go
@@ -93,6 +93,8 @@ func (s Server) handleAPIV1(w http.ResponseWriter, r *http.Request) {
 		s.handleIgnitionTemplates(w, r)
 	case p == "images/coreos" || strings.HasPrefix(p, "images/coreos/"):
 		s.handleImages(w, r)
+	case p == "logs":
+		s.handleLogs(w, r)
 	case strings.HasPrefix(p, "machines"):
 		s.handleMachines(w, r)
 	case strings.HasPrefix(p, "state/"):
@@ -100,7 +102,6 @@ func (s Server) handleAPIV1(w http.ResponseWriter, r *http.Request) {
 	default:
 		renderError(r.Context(), w, APIErrNotFound)
 	}
-
 }
 
 // hasPermission returns true if the request has a permission to the resource


### PR DESCRIPTION
This series of commits implements an audit logging framework for sabakan.

It does not yet record logs nor implement `sabactl log` subcommand.
They will be implemented in another pull request.