### PR TITLE
Enable multi-queue I/O scheduler for netboot hosts

### DIFF
--- a/web/coreos.go
+++ b/web/coreos.go
@@ -21,7 +21,7 @@ chain %s/${serial}%s
 
 set base-url %s
 set ignition-id %s
-kernel ${base-url}/coreos/kernel initrd=initrd.gz coreos.first_boot=1 coreos.config.url=${base-url}/ignitions/${serial}/${ignition-id} %s
+kernel ${base-url}/coreos/kernel initrd=initrd.gz coreos.first_boot=1 coreos.config.url=${base-url}/ignitions/${serial}/${ignition-id} scsi_mod.use_blk_mq=Y %s
 initrd ${base-url}/coreos/initrd.gz
 boot
 `


### PR DESCRIPTION
- Default scheduler is mq-deadline.
- virtio attached machine is ignored its parameter because
  the virtio_scsi force enables use_blk_mq by scsi driver.
- Expected is that both of Physical machine and Virtual machine use
  the mq-deadline.