### PR TITLE
Use by-path instead of real path on dev mapper

### DIFF
--- a/cmd/sabakan-cryptsetup/storage.go
+++ b/cmd/sabakan-cryptsetup/storage.go
@@ -20,7 +20,6 @@ import (
 type storageDevice struct {
 	id             []byte
 	byPath         string
-	realPath       string
 	key            []byte
 	CommandContext func(context.Context, string, ...string) *cmd.LogCmd
 }
@@ -78,7 +77,7 @@ func (d devfsType) detectStorageDevices(ctx context.Context, patterns []string) 
 				continue
 			}
 
-			sd := &storageDevice{byPath: device, realPath: rp}
+			sd := &storageDevice{byPath: device}
 			err = sd.findID()
 			if err != nil {
 				return nil, err
@@ -219,7 +218,7 @@ func (s *storageDevice) decrypt(ctx context.Context) error {
 		s.CommandContext = cmd.CommandContext
 	}
 
-	cryptName := fmt.Sprintf("%s-%s-%s", prefix, filepath.Base(s.realPath), s.idString())
+	cryptName := fmt.Sprintf("%s-%s", prefix, filepath.Base(s.byPath))
 	c := s.CommandContext(ctx, cryptSetup, "--hash=plain", "--key-file=-",
 		"--cipher="+cipher, "--key-size="+strconv.Itoa(keySize), "--offset="+strconv.Itoa(offset),
 		"--allow-discards", "open", s.byPath, "--type=plain", cryptName)

--- a/cmd/sabakan-cryptsetup/storage_test.go
+++ b/cmd/sabakan-cryptsetup/storage_test.go
@@ -44,8 +44,7 @@ func createPseudoDevice(t *testing.T, dir, backing, device string, deviceMap map
 	}
 
 	deviceMap[device] = &storageDevice{
-		byPath:   devPath,
-		realPath: f.Name(),
+		byPath: devPath,
 	}
 }
 
@@ -67,12 +66,12 @@ func setupTestStorage(t *testing.T, dir string) (map[string]*storageDevice, *dev
 func sameDevices(x, y []*storageDevice) bool {
 	xMap := make(map[string]*storageDevice)
 	for _, d := range x {
-		xMap[d.realPath] = d
+		xMap[d.byPath] = d
 	}
 
 	yMap := make(map[string]*storageDevice)
 	for _, d := range y {
-		yMap[d.realPath] = d
+		yMap[d.byPath] = d
 	}
 
 	return reflect.DeepEqual(xMap, yMap)


### PR DESCRIPTION
Using by-path name is more strict and convenient to manage devices automatically.
