### PR TITLE
Fix remaining deleted image bug

### DIFF
--- a/models/etcd/image_updater.go
+++ b/models/etcd/image_updater.go
@@ -133,11 +133,7 @@ func (d *driver) updateImage(ctx context.Context) error {
 				return err
 			}
 
-			if data, ok := dataMap[os]; ok {
-				data.index = index
-			} else {
-				dataMap[os] = updateData{index, nil}
-			}
+			dataMap[os] = updateData{index, dataMap[os].deleted}
 			continue
 		}
 
@@ -147,12 +143,7 @@ func (d *driver) updateImage(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-
-			if data, ok := dataMap[os]; ok {
-				data.deleted = deleted
-			} else {
-				dataMap[os] = updateData{nil, deleted}
-			}
+			dataMap[os] = updateData{dataMap[os].index, deleted}
 		}
 	}
 


### PR DESCRIPTION
When deleting an image by `sabactl images delete`, the images are remaining on the local disk.

```console
$ sabactl images upload 100.000 kernel initrd
$ sabactl images delete 100.000
$ sabactl images index
[
  {
    "id": "1745.5.0",
    "date": "2018-07-17T22:02:03.097669114Z",
    "urls": [
      "http://10.69.0.3:10080/api/v1/images/coreos/1745.5.0",
      "http://10.69.0.195:10080/api/v1/images/coreos/1745.5.0",
      "http://10.69.1.131:10080/api/v1/images/coreos/1745.5.0"
    ],
    "exists": true
  }
]
$ sudo ls /var/lib/sabakan/images/coreos/
100.000  1745.5.0
```