### PR TITLE
[assets] fix infinite loop upon etcd compaction.

### DIFF
--- a/models/etcd/asset_updater.go
+++ b/models/etcd/asset_updater.go
@@ -298,7 +298,10 @@ func (d *driver) startAssetUpdater(ctx context.Context, ch <-chan EventPool) err
 		}
 
 		// checkpoint
-		d.saveLastRev(ep.Rev)
+		err := d.saveLastRev(ep.Rev)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/models/etcd/watch_stateful.go
+++ b/models/etcd/watch_stateful.go
@@ -47,7 +47,7 @@ func (d *driver) loadLastRev() int64 {
 
 func (d *driver) saveLastRev(rev int64) error {
 	p := filepath.Join(d.dataDir, LastRevFile)
-	f, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0644)
+	f, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_SYNC, 0644)
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,10 @@ RETRY:
 			log.Warn("database has been compacted; re-initializing", map[string]interface{}{
 				"compactedrev": resp.CompactRevision,
 			})
-			d.saveLastRev(0)
+			err := d.saveLastRev(0)
+			if err != nil {
+				return err
+			}
 
 			// the watch will be canceled by the server as described in:
 			// https://godoc.org/github.com/coreos/etcd/clientv3#Watcher

--- a/models/etcd/watch_stateful_test.go
+++ b/models/etcd/watch_stateful_test.go
@@ -1,0 +1,45 @@
+package etcd
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestLastRev(t *testing.T) {
+	t.Parallel()
+
+	d, _ := testNewDriver(t)
+
+	dirName, err := ioutil.TempDir("", "sabakan-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.dataDir = dirName
+	defer os.RemoveAll(dirName)
+
+	rev := d.loadLastRev()
+	if rev != 0 {
+		t.Error("initial revision must be zero")
+	}
+
+	err = d.saveLastRev(123)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rev = d.loadLastRev()
+	if rev != 123 {
+		t.Error("saved revision cannot be loaded")
+	}
+
+	err = d.saveLastRev(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rev = d.loadLastRev()
+	if rev != 0 {
+		t.Error("failed to reset the revision")
+	}
+}

--- a/mtest/Makefile
+++ b/mtest/Makefile
@@ -25,12 +25,13 @@ SSH_PRIVKEY := ./mtest_key
 OUTPUT := ./output
 UBUNTU_IMAGE := ubuntu-18.04-server-cloudimg-amd64.img
 SABACTL := $(OUTPUT)/sabactl
+ETCDCTL := $(OUTPUT)/etcdctl
 MACHINES_JSON := $(OUTPUT)/machines.json
 IPAM_JSON := $(OUTPUT)/ipam.json
 DHCP_JSON := $(OUTPUT)/dhcp.json
 IGNITIONS := $(OUTPUT)/ignitions
 
-export SSH_PRIVKEY SABACTL MACHINES_JSON IPAM_JSON DHCP_JSON IGNITIONS
+export SSH_PRIVKEY SABACTL ETCDCTL MACHINES_JSON IPAM_JSON DHCP_JSON IGNITIONS
 
 
 GENERATED_FILES = $(OUTPUT)/etcd  $(OUTPUT)/etcdctl \

--- a/mtest/assets_test.go
+++ b/mtest/assets_test.go
@@ -3,6 +3,7 @@ package mtest
 import (
 	"encoding/json"
 	"os"
+	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -44,5 +45,66 @@ var _ = Describe("assets", func() {
 			}
 			return true
 		}).Should(BeTrue())
+
+		By("Stopping host2 sabakan")
+		Expect(stopHost2Sabakan()).To(Succeed())
+
+		By("Adding two assets")
+		f1 := localTempFile("updated 1")
+		defer os.Remove(f1.Name())
+		sabactl("assets", "upload", "test2", f1.Name())
+		f2 := localTempFile("updated 2")
+		defer os.Remove(f2.Name())
+		sabactl("assets", "upload", "test2", f2.Name())
+
+		By("Getting the current revision")
+		stdout := etcdctl("get", "/", "-w=json")
+		v := &struct {
+			Header struct {
+				Revision int `json:"revision"`
+			} `json:"header"`
+		}{}
+		Expect(json.Unmarshal(stdout, v)).To(Succeed())
+		currentRevision := v.Header.Revision
+
+		By("Executing compaction")
+		etcdctl("compaction", "--physical=true", strconv.Itoa(currentRevision))
+
+		By("Restarting host2 sabakan")
+		Expect(startHost2Sabakan()).To(Succeed())
+
+		By("Confirming that sabakan can get the latest asset again")
+		Eventually(func() bool {
+			var info struct {
+				Urls []string `json:"urls"`
+			}
+
+			stdout := sabactl("assets", "info", "test2")
+			err := json.Unmarshal(stdout, &info)
+			if err != nil {
+				return false
+			}
+			return len(info.Urls) == 3
+		}).Should(BeTrue())
 	})
 })
+
+func stopHost2Sabakan() error {
+	host2Client := sshClients[host2]
+	sess, err := host2Client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer sess.Close()
+	return sess.Run("sudo systemctl stop sabakan.service")
+}
+
+func startHost2Sabakan() error {
+	host2Client := sshClients[host2]
+	sess, err := host2Client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer sess.Close()
+	return sess.Run("sudo systemd-run --unit=sabakan.service /data/sabakan -config-file /etc/sabakan.yml")
+}

--- a/mtest/env.go
+++ b/mtest/env.go
@@ -12,6 +12,7 @@ var (
 	worker           = os.Getenv("WORKER")
 	sshKeyFile       = os.Getenv("SSH_PRIVKEY")
 	sabactlPath      = os.Getenv("SABACTL")
+	etcdctlPath      = os.Getenv("ETCDCTL")
 	ipamJSONPath     = os.Getenv("IPAM_JSON")
 	dhcpJSONPath     = os.Getenv("DHCP_JSON")
 	machinesJSONPath = os.Getenv("MACHINES_JSON")

--- a/mtest/run_test.go
+++ b/mtest/run_test.go
@@ -164,3 +164,14 @@ func sabactl(args ...string) []byte {
 	Eventually(session).Should(gexec.Exit(0))
 	return stdout.Bytes()
 }
+
+func etcdctl(args ...string) []byte {
+	args = append([]string{"--endpoints", "http://" + host1 + ":2379"}, args...)
+	command := exec.Command(etcdctlPath, args...)
+	command.Env = append(command.Env, "ETCDCTL_API=3")
+	stdout := new(bytes.Buffer)
+	session, err := gexec.Start(command, stdout, GinkgoWriter)
+	Ω(err).ShouldNot(HaveOccurred())
+	Eventually(session).Should(gexec.Exit(0))
+	return stdout.Bytes()
+}


### PR DESCRIPTION
Assets monitors etcd changes statefully by storing the last watched
revision in the filesystem.  When etcd compacted the database while
sabakan is stopping, sabakan would not be able to resume the stateful
watch from the saved revision.

In this case, sabakan resets the revision stored in the filesystem
to zero and re-synchronize all assets with the current database.

Unfortunately, sabakan could generate corrupted revision file
because it did not truncate the revision file.  This commit
truncates the revision file properly, and adds unit tests for them.