### PR TITLE
Add kernel parameters support

### DIFF
--- a/client/kernel_params.go
+++ b/client/kernel_params.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"context"
+	"path"
+	"strings"
+
+	"github.com/cybozu-go/sabakan"
+)
+
+// KernelParamsGet retrieves kernel parameters
+func KernelParamsGet(ctx context.Context, os string) (sabakan.KernelParams, *Status) {
+	body, status := client.getBytes(ctx, path.Join("kernel_params", os))
+	if status != nil {
+		return "", status
+	}
+
+	return sabakan.KernelParams(body), status
+}
+
+// KernelParamsSet sets kernel parameters
+func KernelParamsSet(ctx context.Context, os string, params sabakan.KernelParams) *Status {
+	r := strings.NewReader(string(params))
+	return client.sendRequest(ctx, "PUT", path.Join("kernel_params", os), r)
+}

--- a/cmd/sabactl/kernel_params.go
+++ b/cmd/sabactl/kernel_params.go
@@ -19,18 +19,18 @@ func (c *kernelParamsCmd) SetFlags(f *flag.FlagSet) {
 }
 
 func (c *kernelParamsCmd) Execute(ctx context.Context, f *flag.FlagSet) subcommands.ExitStatus {
-	newc := newCommander(f, "kernelparams")
+	newc := newCommander(f, "kernel-params")
 	newc.Register(kernelParamsGetCommand(c.os), "")
 	newc.Register(kernelParamsSetCommand(c.os), "")
 	return newc.Execute(ctx)
 }
 
-func kernelParamsComand() subcommands.Command {
+func kernelParamsCommand() subcommands.Command {
 	return subcmd{
 		&kernelParamsCmd{"coreos"},
-		"kernelparams",
+		"kernel-params",
 		"set/get kernel parameters",
-		"kernelparams ACTION ...",
+		"kernel-params ACTION ...",
 	}
 }
 

--- a/cmd/sabactl/kernerl_params.go
+++ b/cmd/sabactl/kernerl_params.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/cybozu-go/sabakan"
+	"github.com/cybozu-go/sabakan/client"
+	"github.com/google/subcommands"
+)
+
+type kernelParamsCmd struct {
+	os string
+}
+
+func (c *kernelParamsCmd) SetFlags(f *flag.FlagSet) {
+	f.StringVar(&c.os, "os", "coreos", "OS identifier")
+}
+
+func (c *kernelParamsCmd) Execute(ctx context.Context, f *flag.FlagSet) subcommands.ExitStatus {
+	newc := newCommander(f, "kernelparams")
+	newc.Register(kernelParamsGetCommand(c.os), "")
+	newc.Register(kernelParamsSetCommand(c.os), "")
+	return newc.Execute(ctx)
+}
+
+func kernelParamsComand() subcommands.Command {
+	return subcmd{
+		&kernelParamsCmd{"coreos"},
+		"kernelparams",
+		"set/get kernel parameters",
+		"kernelparams ACTION ...",
+	}
+}
+
+type kernelParamsGetCmd struct {
+	os string
+}
+
+func (c kernelParamsGetCmd) SetFlags(f *flag.FlagSet) {}
+
+func (c kernelParamsGetCmd) Execute(ctx context.Context, f *flag.FlagSet) subcommands.ExitStatus {
+	kernelParams, err := client.KernelParamsGet(ctx, c.os)
+	if err != nil {
+		return handleError(err)
+	}
+	fmt.Println(kernelParams)
+
+	return client.ExitSuccess
+}
+
+func kernelParamsGetCommand(os string) subcommands.Command {
+	return subcmd{
+		kernelParamsGetCmd{os: os},
+		"get",
+		"get kernel parameters",
+		"get",
+	}
+}
+
+type kernelParamsSetCmd struct {
+	os string
+}
+
+func (c kernelParamsSetCmd) SetFlags(f *flag.FlagSet) {}
+
+func (c kernelParamsSetCmd) Execute(ctx context.Context, f *flag.FlagSet) subcommands.ExitStatus {
+	if len(f.Args()) != 1 {
+		f.Usage()
+		return client.ExitUsageError
+	}
+
+	err := client.KernelParamsSet(ctx, c.os, sabakan.KernelParams(f.Arg(0)))
+	return handleError(err)
+}
+
+func kernelParamsSetCommand(os string) subcommands.Command {
+	return subcmd{
+		imagesUploadCmd{os: os},
+		"set",
+		"set kernel parameters",
+		"set KERNEL_PARAMS",
+	}
+}

--- a/cmd/sabactl/kernerl_params.go
+++ b/cmd/sabactl/kernerl_params.go
@@ -77,7 +77,7 @@ func (c kernelParamsSetCmd) Execute(ctx context.Context, f *flag.FlagSet) subcom
 
 func kernelParamsSetCommand(os string) subcommands.Command {
 	return subcmd{
-		imagesUploadCmd{os: os},
+		kernelParamsSetCmd{os: os},
 		"set",
 		"set kernel parameters",
 		"set KERNEL_PARAMS",

--- a/cmd/sabactl/main.go
+++ b/cmd/sabactl/main.go
@@ -28,6 +28,7 @@ func main() {
 	subcommands.Register(ignitionsCommand(), "")
 	subcommands.Register(cryptsCommand(), "")
 	subcommands.Register(logsCommand(), "")
+	subcommands.Register(kernelParamsComand(), "")
 	flag.Parse()
 	cmd.LogConfig{}.Apply()
 

--- a/cmd/sabactl/main.go
+++ b/cmd/sabactl/main.go
@@ -28,7 +28,7 @@ func main() {
 	subcommands.Register(ignitionsCommand(), "")
 	subcommands.Register(cryptsCommand(), "")
 	subcommands.Register(logsCommand(), "")
-	subcommands.Register(kernelParamsComand(), "")
+	subcommands.Register(kernelParamsCommand(), "")
 	flag.Parse()
 	cmd.LogConfig{}.Apply()
 

--- a/dhcpd/discover.go
+++ b/dhcpd/discover.go
@@ -1,10 +1,8 @@
 package dhcpd
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
-	"net"
 	"strings"
 	"time"
 
@@ -54,11 +52,6 @@ func isIPXEBoot(pkt *dhcp4.Packet) bool {
 	}
 
 	return ucls == "iPXE"
-}
-
-func isQemuMacAddress(mac net.HardwareAddr) bool {
-	// "52:54:00" comes from placemat.
-	return bytes.HasPrefix(mac, []byte{0x52, 0x54, 0x00})
 }
 
 func (h DHCPHandler) handleDiscover(ctx context.Context, pkt *dhcp4.Packet, intf Interface) (*dhcp4.Packet, error) {
@@ -111,9 +104,6 @@ func (h DHCPHandler) handleDiscover(ctx context.Context, pkt *dhcp4.Packet, intf
 		}))
 		// iPXE script to boot CoreOS Container Linux
 		resp.BootFilename = h.makeBootAPIURL("coreos/ipxe")
-		if isQemuMacAddress(pkt.HardwareAddr) {
-			resp.BootFilename += "?serial=1"
-		}
 	}
 
 	return resp, nil

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,6 +33,8 @@ REST API
 * [GET /api/v1/crypts](#getcrypts)
 * [DELETE /api/v1/crypts](#deletecrypts)
 * [GET /api/v1/logs](#getlogs)
+* [PUT /api/v1/kernel_params/coreos](#putkernelparams)
+* [GET /api/v1/kernel_params/coreos](#getkernelparams)
 
 ## Access control
 
@@ -851,4 +853,49 @@ $ curl -s 'localhost:10080/api/v1/logs?since=20180404&until=20180707'
 {"ts":"2018-07-05T00:21:02.486519609Z","rev":"2","user":"root","ip":"127.0.0.1","host":"rkt-9ac1f230-64c4-40b1-a67c-52c297435d8b","category":"ipam","instance":"config","action":"put","detail":"{\"max-nodes-in-rack\":28,\"node-ipv4-pool\":\"10.69.0.0/20\",\"node-ipv4-range-size\":6,\"node-ipv4-range-mask\":26,\"node-ip-per-node\":3,\"node-index-offset\":3,\"bmc-ipv4-pool\":\"10.72.16.0/20\",\"bmc-ipv4-offset\":\"0.0.1.0\",\"bmc-ipv4-range-size\":5,\"bmc-ipv4-range-mask\":20}"}
 {"ts":"2018-07-05T00:21:02.56064736Z","rev":"4","user":"root","ip":"127.0.0.1","host":"rkt-9ac1f230-64c4-40b1-a67c-52c297435d8b","category":"dhcp","instance":"config","action":"put","detail":"{\"gateway-offset\":1,\"lease-minutes\":60}"}
 ......
+```
+
+## <a name="putkernelparams" />`PUT /api/v1/kernel_params/coreos`
+
+Create or update kernel parameters.  If one or more nodes have been registered in sabakan, kernel parameters cannot be updated.
+
+**Successful response**
+
+- HTTP status code: 200 OK
+
+**Failure responses**
+
+- Kernel parameters is empty.
+
+  HTTP status code: 400 Bad Request
+
+**Example**
+
+```console
+$ curl -s -XPUT 'localhost:10080/api/v1/kernel_params/coreos' -d '
+console=ttyS0 coreos.autologin=ttyS0
+'
+```
+
+## <a name="getkernelparams" />`GET /api/v1/kernel_params/coreos`
+
+Get kernel parameters.
+
+**Successful response**
+
+- HTTP status code: 200 OK
+- HTTP response header: `Content-Type: text/plain`
+- HTTP response body: Current kernel parameters
+
+**Failure responses**
+
+- Kernel parameters have not been created
+
+  HTTP status code: 404 Not Found
+
+**Example**
+
+```console
+$ curl -s -XGET 'localhost:10080/api/v1/kernel_params/coreos'
+console=ttyS0 coreos.autologin=ttyS0
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -857,7 +857,7 @@ $ curl -s 'localhost:10080/api/v1/logs?since=20180404&until=20180707'
 
 ## <a name="putkernelparams" />`PUT /api/v1/kernel_params/coreos`
 
-Create or update kernel parameters.  If one or more nodes have been registered in sabakan, kernel parameters cannot be updated.
+Create or update kernel parameters on iPXE booting.
 
 **Successful response**
 
@@ -865,7 +865,7 @@ Create or update kernel parameters.  If one or more nodes have been registered i
 
 **Failure responses**
 
-- Kernel parameters is empty.
+- Kernel params string contains contains non ASCII character(s) or control sequence(s).
 
   HTTP status code: 400 Bad Request
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -865,7 +865,7 @@ Create or update kernel parameters on iPXE booting.
 
 **Failure responses**
 
-- Kernel params string contains contains non ASCII character(s) or control sequence(s).
+- Kernel params string contains non ASCII character(s) or control sequence(s).
 
   HTTP status code: 400 Bad Request
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -14,6 +14,7 @@ your servers with CoreOS Container Linux.
   * [Configure DHCP](#dhcp)
   * [Upload CoreOS Container Linux](#upload)
   * [Register machines](#register)
+  * [Register kernel parameters](#kernelparams)
 * [What's next](#whatsnext)
 
 ## <a name="setup" />Setup sabakan
@@ -158,6 +159,15 @@ CoreOS Container Linux using [UEFI HTTP Boot][HTTPBoot].
 CoreOS can be initialized at first boot by [ignition][].
 Sabakan can generate ignition configuration from templates.
 Read [ignition.md](ignition.md) for details.
+
+### <a name="kernelparams" />Register kernel parameters
+
+Put the kernel parameteres to sabakan:
+```console
+$ sabactl dhcp set "console=ttyS0 coreos.autologin=ttyS0"
+```
+
+When iPXE script is acquired, this value is passed as the kernel parameter of iPXE script.
 
 ## <a name="whatsnext" /> What's next
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -164,7 +164,7 @@ Read [ignition.md](ignition.md) for details.
 
 Put the kernel parameteres to sabakan:
 ```console
-$ sabactl dhcp set "console=ttyS0 coreos.autologin=ttyS0"
+$ sabactl kernel-params set "console=ttyS0 coreos.autologin=ttyS0"
 ```
 
 When iPXE script is acquired, this value is passed as the kernel parameter of iPXE script.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -162,7 +162,7 @@ Read [ignition.md](ignition.md) for details.
 
 ### <a name="kernelparams" />Register kernel parameters
 
-Put the kernel parameteres to sabakan:
+Put the kernel parameters to sabakan:
 ```console
 $ sabactl kernel-params set "console=ttyS0 coreos.autologin=ttyS0"
 ```

--- a/docs/sabactl.md
+++ b/docs/sabactl.md
@@ -228,3 +228,25 @@ of `START_DATE` are retrieved.
 
 If `START_DATE` and `END_DATE` is given, logs between them are
 retrieved.
+
+`sabactl kernelparams [-os OS] set`
+------------------
+
+Set/update kernel parameters.
+
+* `-os`: specifies OS of the image.  Default is "coreos"
+
+```console
+$ sabactl kernelparams set "<param0>=<value0> <param1>=<value1> ..."
+```
+
+`sabactl kernelparams [-os OS] get`
+------------------
+
+Get the current kernel parameters.
+
+* `-os`: specifies OS of the image.  Default is "coreos"
+
+```console
+$ sabactl kernelparams get
+```

--- a/docs/sabactl.md
+++ b/docs/sabactl.md
@@ -229,7 +229,7 @@ of `START_DATE` are retrieved.
 If `START_DATE` and `END_DATE` is given, logs between them are
 retrieved.
 
-`sabactl kernelparams [-os OS] set`
+`sabactl kernel-params [-os OS] set`
 ------------------
 
 Set/update kernel parameters.
@@ -237,10 +237,10 @@ Set/update kernel parameters.
 * `-os`: specifies OS of the image.  Default is "coreos"
 
 ```console
-$ sabactl kernelparams set "<param0>=<value0> <param1>=<value1> ..."
+$ sabactl kernel-params set "<param0>=<value0> <param1>=<value1> ..."
 ```
 
-`sabactl kernelparams [-os OS] get`
+`sabactl kernel-params [-os OS] get`
 ------------------
 
 Get the current kernel parameters.
@@ -248,5 +248,5 @@ Get the current kernel parameters.
 * `-os`: specifies OS of the image.  Default is "coreos"
 
 ```console
-$ sabactl kernelparams get
+$ sabactl kernel-params get
 ```

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -119,3 +119,8 @@ The value is JSON having fields defined in [audit log](audit.md).
 
 This key stores RFC3339-format timestamp to record the last compaction
 of audit logs.
+
+`<prefix>/kernel-params/coreos`
+----------------
+
+This type of key holds kernel parameters.

--- a/kernel_params.go
+++ b/kernel_params.go
@@ -1,0 +1,3 @@
+package sabakan
+
+type KernelParams string

--- a/kernel_params.go
+++ b/kernel_params.go
@@ -1,3 +1,4 @@
 package sabakan
 
+// KernelParams is a kernel parameters.
 type KernelParams string

--- a/kernel_params.go
+++ b/kernel_params.go
@@ -1,4 +1,15 @@
 package sabakan
 
+import "regexp"
+
+var (
+	reValidKernelParams = regexp.MustCompile(`^[0-9a-zA-Z.,-_= ]*$`)
+)
+
+// IsValidKernelParams returns true if s is valid as an kernel params
+func IsValidKernelParams(s string) bool {
+	return reValidKernelParams.MatchString(s)
+}
+
 // KernelParams is a kernel parameters.
 type KernelParams string

--- a/kernel_params_test.go
+++ b/kernel_params_test.go
@@ -1,0 +1,27 @@
+package sabakan
+
+import "testing"
+
+func TestIsVlidKernelParams(t *testing.T) {
+	t.Parallel()
+
+	valids := []string{
+		"console=ttyS0 coreos.autologin=ttyS0 glt",
+		"",
+	}
+	for _, p := range valids {
+		if !IsValidKernelParams(p) {
+			t.Error(`!IsValidKernelParams(p): `, p)
+		}
+	}
+
+	invalids := []string{
+		"hello=workd\ngood=morning",
+		"console=寿司",
+	}
+	for _, p := range invalids {
+		if IsValidKernelParams(p) {
+			t.Error(`IsValidKernelParams(p): `, p)
+		}
+	}
+}

--- a/model.go
+++ b/model.go
@@ -96,8 +96,8 @@ type LogModel interface {
 
 // KernelParamsModel is an interface for kernel parameters.
 type KernelParamsModel interface {
-	PutParams(ctx context.Context, os string, params KernelParams) error
-	GetParams(ctx context.Context, os string) (KernelParams, error)
+	PutParams(ctx context.Context, os string, params string) error
+	GetParams(ctx context.Context, os string) (string, error)
 }
 
 // Runner is an interface to run the underlying threads.

--- a/model.go
+++ b/model.go
@@ -94,6 +94,12 @@ type LogModel interface {
 	Dump(ctx context.Context, since, until time.Time, w io.Writer) error
 }
 
+// KernelParamsModel is an interface for kernel parameters.
+type KernelParamsModel interface {
+	PutParams(ctx context.Context, os string, params KernelParams) error
+	GetParams(ctx context.Context, os string) (KernelParams, error)
+}
+
 // Runner is an interface to run the underlying threads.
 //
 // The caller must pass a channel as follows.
@@ -112,12 +118,13 @@ type Runner interface {
 // Model is a struct that consists of sub-models.
 type Model struct {
 	Runner
-	Storage  StorageModel
-	Machine  MachineModel
-	IPAM     IPAMModel
-	DHCP     DHCPModel
-	Image    ImageModel
-	Asset    AssetModel
-	Ignition IgnitionModel
-	Log      LogModel
+	Storage      StorageModel
+	Machine      MachineModel
+	IPAM         IPAMModel
+	DHCP         DHCPModel
+	Image        ImageModel
+	Asset        AssetModel
+	Ignition     IgnitionModel
+	Log          LogModel
+	KernelParams KernelParamsModel
 }

--- a/models/etcd/constants.go
+++ b/models/etcd/constants.go
@@ -4,18 +4,19 @@ import "time"
 
 // Internal schema keys.
 const (
-	KeyCrypts      = "crypts/"
-	KeyDHCP        = "dhcp"
-	KeyIPAM        = "ipam"
-	KeyLeaseUsages = "lease-usages/"
-	KeyMachines    = "machines/"
-	KeyNodeIndices = "node-indices/"
-	KeyImages      = "images/"
-	KeyAssets      = "assets/"
-	KeyAssetsID    = "assets"
-	KeyIgnitions   = "ignitions/"
-	KeyAudit       = "audit/"
-	KeyAuditLastGC = "audit"
+	KeyCrypts       = "crypts/"
+	KeyDHCP         = "dhcp"
+	KeyIPAM         = "ipam"
+	KeyLeaseUsages  = "lease-usages/"
+	KeyMachines     = "machines/"
+	KeyNodeIndices  = "node-indices/"
+	KeyImages       = "images/"
+	KeyAssets       = "assets/"
+	KeyAssetsID     = "assets"
+	KeyIgnitions    = "ignitions/"
+	KeyAudit        = "audit/"
+	KeyAuditLastGC  = "audit"
+	KeyKernelParams = "kernel-params/"
 )
 
 // MaxDeleted is the maximum number of deleted image IDs stored in etcd.

--- a/models/etcd/driver.go
+++ b/models/etcd/driver.go
@@ -35,15 +35,16 @@ func NewModel(client *clientv3.Client, dataDir string, advertiseURL *url.URL) sa
 		mi:           newMachinesIndex(),
 	}
 	return sabakan.Model{
-		Runner:   d,
-		Storage:  d,
-		Machine:  machineDriver{d},
-		IPAM:     ipamDriver{d},
-		DHCP:     dhcpDriver{d},
-		Image:    imageDriver{d},
-		Asset:    assetDriver{d},
-		Log:      logDriver{d},
-		Ignition: d,
+		Runner:       d,
+		Storage:      d,
+		Machine:      machineDriver{d},
+		IPAM:         ipamDriver{d},
+		DHCP:         dhcpDriver{d},
+		Image:        imageDriver{d},
+		Asset:        assetDriver{d},
+		Log:          logDriver{d},
+		Ignition:     d,
+		KernelParams: kernelParamsDriver{d},
 	}
 }
 

--- a/models/etcd/kernel_params.go
+++ b/models/etcd/kernel_params.go
@@ -10,7 +10,7 @@ import (
 
 func (d *driver) putParams(ctx context.Context, os string, params sabakan.KernelParams) error {
 	r := regexp.MustCompile(`^([[:print:]])+$`)
-	if r.MatchString(string(params)) {
+	if !r.MatchString(string(params)) {
 		return sabakan.ErrBadRequest
 	}
 

--- a/models/etcd/kernel_params.go
+++ b/models/etcd/kernel_params.go
@@ -1,0 +1,21 @@
+package etcd
+
+//
+// import (
+// 	"errors"
+//
+// 	"github.com/coreos/etcd/clientv3"
+// )
+//
+// func (d *driver) getKernelParams() (string, error) {
+// 	v := d.kernelParams.Load()
+// 	if v == nil {
+// 		return nil, errors.New("kernelParams is not set")
+// 	}
+//
+// 	return v.(string), nil
+// }
+//
+// func (d *driver) handleKernelParams(ev *clientv3.Event) error {
+// 	return nil
+// }

--- a/models/etcd/kernel_params.go
+++ b/models/etcd/kernel_params.go
@@ -3,11 +3,17 @@ package etcd
 import (
 	"context"
 	"path"
+	"regexp"
 
 	"github.com/cybozu-go/sabakan"
 )
 
 func (d *driver) putParams(ctx context.Context, os string, params sabakan.KernelParams) error {
+	r := regexp.MustCompile(`^([[:print:]])+$`)
+	if r.MatchString(string(params)) {
+		return sabakan.ErrBadRequest
+	}
+
 	key := path.Join(KeyKernelParams, os)
 	_, err := d.client.Put(ctx, key, string(params))
 	if err != nil {

--- a/models/etcd/kernel_params.go
+++ b/models/etcd/kernel_params.go
@@ -1,21 +1,45 @@
 package etcd
 
-//
-// import (
-// 	"errors"
-//
-// 	"github.com/coreos/etcd/clientv3"
-// )
-//
-// func (d *driver) getKernelParams() (string, error) {
-// 	v := d.kernelParams.Load()
-// 	if v == nil {
-// 		return nil, errors.New("kernelParams is not set")
-// 	}
-//
-// 	return v.(string), nil
-// }
-//
-// func (d *driver) handleKernelParams(ev *clientv3.Event) error {
-// 	return nil
-// }
+import (
+	"context"
+	"path"
+
+	"github.com/cybozu-go/sabakan"
+)
+
+func (d *driver) putParams(ctx context.Context, os string, params sabakan.KernelParams) error {
+	key := path.Join(KeyKernelParams, os)
+	_, err := d.client.Put(ctx, key, string(params))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *driver) getParams(ctx context.Context, os string) (sabakan.KernelParams, error) {
+	key := path.Join(KeyKernelParams, os)
+	resp, err := d.client.Get(ctx, key)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.Count == 0 {
+		return "", sabakan.ErrNotFound
+	}
+
+	v := resp.Kvs[0].Value
+	return sabakan.KernelParams(v), nil
+}
+
+type kernelParamsDriver struct {
+	*driver
+}
+
+func (d kernelParamsDriver) PutParams(ctx context.Context, os string, params sabakan.KernelParams) error {
+	return d.putParams(ctx, os, params)
+}
+
+func (d kernelParamsDriver) GetParams(ctx context.Context, os string) (sabakan.KernelParams, error) {
+	return d.getParams(ctx, os)
+}

--- a/models/etcd/kernel_params.go
+++ b/models/etcd/kernel_params.go
@@ -3,17 +3,11 @@ package etcd
 import (
 	"context"
 	"path"
-	"regexp"
 
 	"github.com/cybozu-go/sabakan"
 )
 
-func (d *driver) putParams(ctx context.Context, os string, params sabakan.KernelParams) error {
-	r := regexp.MustCompile(`^([[:print:]])+$`)
-	if !r.MatchString(string(params)) {
-		return sabakan.ErrBadRequest
-	}
-
+func (d *driver) putParams(ctx context.Context, os string, params string) error {
 	key := path.Join(KeyKernelParams, os)
 	_, err := d.client.Put(ctx, key, string(params))
 	if err != nil {
@@ -23,7 +17,7 @@ func (d *driver) putParams(ctx context.Context, os string, params sabakan.Kernel
 	return nil
 }
 
-func (d *driver) getParams(ctx context.Context, os string) (sabakan.KernelParams, error) {
+func (d *driver) getParams(ctx context.Context, os string) (string, error) {
 	key := path.Join(KeyKernelParams, os)
 	resp, err := d.client.Get(ctx, key)
 	if err != nil {
@@ -35,17 +29,17 @@ func (d *driver) getParams(ctx context.Context, os string) (sabakan.KernelParams
 	}
 
 	v := resp.Kvs[0].Value
-	return sabakan.KernelParams(v), nil
+	return string(v), nil
 }
 
 type kernelParamsDriver struct {
 	*driver
 }
 
-func (d kernelParamsDriver) PutParams(ctx context.Context, os string, params sabakan.KernelParams) error {
+func (d kernelParamsDriver) PutParams(ctx context.Context, os string, params string) error {
 	return d.putParams(ctx, os, params)
 }
 
-func (d kernelParamsDriver) GetParams(ctx context.Context, os string) (sabakan.KernelParams, error) {
+func (d kernelParamsDriver) GetParams(ctx context.Context, os string) (string, error) {
 	return d.getParams(ctx, os)
 }

--- a/models/mock/driver.go
+++ b/models/mock/driver.go
@@ -24,15 +24,16 @@ func NewModel() sabakan.Model {
 		storage:  make(map[string][]byte),
 	}
 	return sabakan.Model{
-		Runner:   d,
-		IPAM:     ipamDriver{d},
-		Machine:  machineDriver{d},
-		Storage:  d,
-		DHCP:     newDHCPDriver(d),
-		Image:    newImageDriver(),
-		Asset:    newAssetDriver(),
-		Ignition: newIgnitionDriver(),
-		Log:      logDriver{d},
+		Runner:       d,
+		IPAM:         ipamDriver{d},
+		Machine:      machineDriver{d},
+		Storage:      d,
+		DHCP:         newDHCPDriver(d),
+		Image:        newImageDriver(),
+		Asset:        newAssetDriver(),
+		Ignition:     newIgnitionDriver(),
+		Log:          logDriver{d},
+		KernelParams: newKernelParamsDriver(),
 	}
 }
 

--- a/models/mock/kernel_params.go
+++ b/models/mock/kernel_params.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"context"
-	"errors"
 	"sync"
 
 	"github.com/cybozu-go/sabakan"
@@ -35,5 +34,5 @@ func (d *kernelParamsDriver) GetParams(ctx context.Context, os string) (sabakan.
 		return val, nil
 	}
 
-	return "", errors.New("KernelParams is not set")
+	return "", sabakan.ErrNotFound
 }

--- a/models/mock/kernel_params.go
+++ b/models/mock/kernel_params.go
@@ -1,0 +1,39 @@
+package mock
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/cybozu-go/sabakan"
+)
+
+type kernelParamsDriver struct {
+	mu           sync.Mutex
+	kernelParams map[string]sabakan.KernelParams
+}
+
+func newKernelParamsDriver() *kernelParamsDriver {
+	return &kernelParamsDriver{
+		kernelParams: make(map[string]sabakan.KernelParams),
+	}
+}
+
+func (d *kernelParamsDriver) PutParams(ctx context.Context, os string, params sabakan.KernelParams) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.kernelParams[os] = params
+	return nil
+}
+
+func (d *kernelParamsDriver) GetParams(ctx context.Context, os string) (sabakan.KernelParams, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if val, ok := d.kernelParams[os]; ok {
+		return val, nil
+	}
+
+	return "", errors.New("KernelParams is not set")
+}

--- a/models/mock/kernel_params.go
+++ b/models/mock/kernel_params.go
@@ -9,16 +9,16 @@ import (
 
 type kernelParamsDriver struct {
 	mu           sync.Mutex
-	kernelParams map[string]sabakan.KernelParams
+	kernelParams map[string]string
 }
 
 func newKernelParamsDriver() *kernelParamsDriver {
 	return &kernelParamsDriver{
-		kernelParams: make(map[string]sabakan.KernelParams),
+		kernelParams: make(map[string]string),
 	}
 }
 
-func (d *kernelParamsDriver) PutParams(ctx context.Context, os string, params sabakan.KernelParams) error {
+func (d *kernelParamsDriver) PutParams(ctx context.Context, os string, params string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -26,7 +26,7 @@ func (d *kernelParamsDriver) PutParams(ctx context.Context, os string, params sa
 	return nil
 }
 
-func (d *kernelParamsDriver) GetParams(ctx context.Context, os string) (sabakan.KernelParams, error) {
+func (d *kernelParamsDriver) GetParams(ctx context.Context, os string) (string, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 

--- a/mtest/netboot_test.go
+++ b/mtest/netboot_test.go
@@ -1,6 +1,7 @@
 package mtest
 
 import (
+	"bytes"
 	"encoding/json"
 
 	. "github.com/onsi/ginkgo"
@@ -36,15 +37,38 @@ var _ = Describe("netboot", func() {
 			return false
 		}).Should(BeTrue())
 
+		By("Set-up kernel params")
+		sabactl("kernel-params", "set", "coreos.autologin=ttyS0")
+
 		By("Waiting worker to boot")
 		sshKey, err := parsePrivateKey()
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() error {
-			_, err := sshTo(worker, sshKey)
+			c, err := sshTo(worker, sshKey)
+			if err == nil {
+				c.Close()
+			}
 			return err
 		}).Should(Succeed())
 
+		By("Waiting worker to boot")
+		cli, err := sshTo(worker, sshKey)
+		Expect(err).NotTo(HaveOccurred())
+		defer cli.Close()
+
+		sess, err := cli.NewSession()
+		Expect(err).NotTo(HaveOccurred())
+		var stdout, stderr bytes.Buffer
+		sess.Stdout = &stdout
+		sess.Stderr = &stderr
+		err = sess.Run("cat /proc/cmdline")
+		Expect(err).NotTo(HaveOccurred())
+		sess.Close()
+
+		Expect(stdout.String()).To(ContainSubstring("coreos.autologin=ttyS0"))
+
+		By("Waiting worker to boot")
 		By("Removing the image from the index")
 		sabactl("images", "delete", coreosVersion)
 

--- a/web/coreos.go
+++ b/web/coreos.go
@@ -14,7 +14,7 @@ import (
 const (
 	// iPXE script specs can be found at http://ipxe.org/cfg and http://ipxe.org/cmd
 	redirectiPXETemplate = `#!ipxe
-chain %s/${serial}%s
+chain %s/${serial}
 `
 
 	coreOSiPXETemplate = `#!ipxe
@@ -52,14 +52,9 @@ func (s Server) handleCoreOS(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s Server) handleCoreOSiPXE(w http.ResponseWriter, r *http.Request) {
-	serial := ""
-	if r.URL.Query().Get("serial") == "1" {
-		serial = "?serial=1"
-	}
-
 	u := *s.MyURL
 	u.Path = path.Join("/api/v1/boot/coreos/ipxe")
-	ipxe := fmt.Sprintf(redirectiPXETemplate, u.String(), serial)
+	ipxe := fmt.Sprintf(redirectiPXETemplate, u.String())
 
 	w.Header().Set("Content-Type", "text/plain; charset=ASCII")
 	w.Write([]byte(ipxe))

--- a/web/coreos.go
+++ b/web/coreos.go
@@ -21,7 +21,7 @@ chain %s/${serial}%s
 
 set base-url %s
 set ignition-id %s
-kernel ${base-url}/coreos/kernel initrd=initrd.gz coreos.first_boot=1 coreos.config.url=${base-url}/ignitions/${serial}/${ignition-id} scsi_mod.use_blk_mq=Y %s
+kernel ${base-url}/coreos/kernel initrd=initrd.gz coreos.first_boot=1 coreos.config.url=${base-url}/ignitions/${serial}/${ignition-id} %s
 initrd ${base-url}/coreos/initrd.gz
 boot
 `

--- a/web/coreos_test.go
+++ b/web/coreos_test.go
@@ -80,7 +80,7 @@ func testHandleiPXEWithSerial(t *testing.T) {
 	}
 
 	w = httptest.NewRecorder()
-	r = httptest.NewRequest("PUT", "/api/v1/kernel_params/coreos", strings.NewReader("test_param=test"))
+	r = httptest.NewRequest("PUT", "/api/v1/kernel_params/coreos", strings.NewReader("console=ttyS0 coreos.autologin=ttyS0"))
 	handler.ServeHTTP(w, r)
 
 	resp = w.Result()
@@ -100,7 +100,7 @@ func testHandleiPXEWithSerial(t *testing.T) {
 	if !strings.Contains(string(body), "kernel") {
 		t.Error("unexpected ipxe script:", string(body))
 	}
-	if !strings.Contains(string(body), "test_param=test") {
+	if !strings.Contains(string(body), "console=ttyS0 coreos.autologin=ttyS0") {
 		t.Error("kernel parameter is not contained", string(body))
 	}
 

--- a/web/coreos_test.go
+++ b/web/coreos_test.go
@@ -58,7 +58,8 @@ func testHandleiPXEWithSerial(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	handler := Server{Model: m, MyURL: url}
+	// handler := Server{Model: m, MyURL: url}
+	handler := newTestServerWithURL(m, url)
 	err = m.Machine.Register(context.Background(), machines)
 	if err != nil {
 		t.Fatal(err)
@@ -79,6 +80,15 @@ func testHandleiPXEWithSerial(t *testing.T) {
 	}
 
 	w = httptest.NewRecorder()
+	r = httptest.NewRequest("PUT", "/api/v1/kernel_params/coreos", strings.NewReader("test_param=test"))
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Error("resp.StatusCode != http.StatusOK:", resp.StatusCode)
+	}
+
+	w = httptest.NewRecorder()
 	r = httptest.NewRequest("GET", "/api/v1/boot/coreos/ipxe/2222abcd", nil)
 	handler.ServeHTTP(w, r)
 
@@ -89,6 +99,9 @@ func testHandleiPXEWithSerial(t *testing.T) {
 	body, _ := ioutil.ReadAll(resp.Body)
 	if !strings.Contains(string(body), "kernel") {
 		t.Error("unexpected ipxe script:", string(body))
+	}
+	if !strings.Contains(string(body), "test_param=test") {
+		t.Error("kernel parameter is not contained", string(body))
 	}
 
 	w = httptest.NewRecorder()

--- a/web/coreos_test.go
+++ b/web/coreos_test.go
@@ -58,7 +58,6 @@ func testHandleiPXEWithSerial(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// handler := Server{Model: m, MyURL: url}
 	handler := newTestServerWithURL(m, url)
 	err = m.Machine.Register(context.Background(), machines)
 	if err != nil {

--- a/web/kernel_params.go
+++ b/web/kernel_params.go
@@ -36,8 +36,12 @@ func (s Server) handleKernelParams(w http.ResponseWriter, r *http.Request) {
 func (s Server) handleKernelParamsGet(w http.ResponseWriter, r *http.Request, os string) {
 	ctx := r.Context()
 	kernelParams, err := s.Model.KernelParams.GetParams(ctx, os)
-	if err != nil {
+	if err == sabakan.ErrNotFound {
 		renderError(ctx, w, APIErrNotFound)
+		return
+	}
+	if err != nil {
+		renderError(ctx, w, InternalServerError(err))
 		return
 	}
 

--- a/web/kernel_params.go
+++ b/web/kernel_params.go
@@ -68,6 +68,10 @@ func (s Server) handleKernelParamsPut(w http.ResponseWriter, r *http.Request, os
 	}
 
 	err = s.Model.KernelParams.PutParams(ctx, os, sabakan.KernelParams(data))
+	if err == sabakan.ErrBadRequest {
+		renderError(r.Context(), w, APIErrBadRequest)
+		return
+	}
 	if err != nil {
 		renderError(ctx, w, InternalServerError(err))
 		return

--- a/web/kernel_params.go
+++ b/web/kernel_params.go
@@ -1,0 +1,73 @@
+package web
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/sabakan"
+)
+
+func (s Server) handleKernelParams(w http.ResponseWriter, r *http.Request) {
+	params := strings.Split(r.URL.Path[len("/api/v1/kernel_params/"):], "/")
+
+	if len(params) < 1 {
+		renderError(r.Context(), w, APIErrBadRequest)
+		return
+	}
+
+	os := params[0]
+	if !sabakan.IsValidImageOS(os) {
+		renderError(r.Context(), w, APIErrBadRequest)
+		return
+	}
+
+	switch r.Method {
+	case "GET":
+		s.handleKernelParamsGet(w, r, os)
+		return
+	case "PUT":
+		s.handleKernelParamsPut(w, r, os)
+		return
+	}
+}
+
+func (s Server) handleKernelParamsGet(w http.ResponseWriter, r *http.Request, os string) {
+	ctx := r.Context()
+	kernelParams, err := s.Model.KernelParams.GetParams(ctx, os)
+	if err != nil {
+		renderError(ctx, w, APIErrNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain")
+	_, err = w.Write([]byte(kernelParams))
+	if err != nil {
+		log.Error("failed to output text", map[string]interface{}{
+			log.FnError: err.Error(),
+		})
+	}
+}
+
+func (s Server) handleKernelParamsPut(w http.ResponseWriter, r *http.Request, os string) {
+	ctx := r.Context()
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		renderError(ctx, w, BadRequest(err.Error()))
+		return
+	}
+	if len(data) == 0 {
+		renderError(ctx, w, BadRequest("Kernel parameters is empty."))
+		return
+	}
+
+	err = s.Model.KernelParams.PutParams(ctx, os, sabakan.KernelParams(data))
+	if err != nil {
+		renderError(ctx, w, InternalServerError(err))
+		return
+	}
+
+	renderJSON(w, nil, http.StatusOK)
+}

--- a/web/kernel_params_test.go
+++ b/web/kernel_params_test.go
@@ -49,4 +49,13 @@ func TestKernelParams(t *testing.T) {
 	if string(data) != "test_param=test" {
 		t.Error("data != test_param=test:", string(data))
 	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("PUT", "/api/v1/kernel_params/coreos", strings.NewReader("conosole=寿司"))
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatal("resp.StatusCode != http.StatusBadRequest:", resp.StatusCode)
+	}
 }

--- a/web/kernel_params_test.go
+++ b/web/kernel_params_test.go
@@ -1,0 +1,52 @@
+package web
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cybozu-go/sabakan/models/mock"
+)
+
+func TestKernelParams(t *testing.T) {
+	m := mock.NewModel()
+	handler := newTestServer(m)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/kernel_params/coreos", nil)
+	handler.ServeHTTP(w, r)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatal("resp.StatusCode != http.StatusNotFound:", resp.StatusCode)
+	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("PUT", "/api/v1/kernel_params/coreos", strings.NewReader("test_param=test"))
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("resp.StatusCode != http.StatusOK:", resp.StatusCode)
+	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/kernel_params/coreos", nil)
+	handler.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("resp.StatusCode != http.StatusOK:", resp.StatusCode)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(data) != "test_param=test" {
+		t.Error("data != test_param=test:", string(data))
+	}
+}

--- a/web/main_test.go
+++ b/web/main_test.go
@@ -2,11 +2,16 @@ package web
 
 import (
 	"net"
+	"net/url"
 
 	"github.com/cybozu-go/sabakan"
 )
 
 func newTestServer(m sabakan.Model) *Server {
+	return newTestServerWithURL(m, nil)
+}
+
+func newTestServerWithURL(m sabakan.Model, u *url.URL) *Server {
 	// httptest.NewRequest() sets RemoteAddr as "192.0.2.1:1234"
 	// https://golang.org/src/net/http/httptest/httptest.go?s=1162:1230#L31
 	_, ipnet, err := net.ParseCIDR("192.0.2.1/24")
@@ -16,5 +21,6 @@ func newTestServer(m sabakan.Model) *Server {
 	return &Server{
 		Model:          m,
 		AllowedRemotes: []*net.IPNet{ipnet},
+		MyURL:          u,
 	}
 }

--- a/web/server.go
+++ b/web/server.go
@@ -99,6 +99,8 @@ func (s Server) handleAPIV1(w http.ResponseWriter, r *http.Request) {
 		s.handleMachines(w, r)
 	case strings.HasPrefix(p, "state/"):
 		s.handleState(w, r)
+	case strings.HasPrefix(p, "kernel_params/"):
+		s.handleKernelParams(w, r)
 	default:
 		renderError(r.Context(), w, APIErrNotFound)
 	}


### PR DESCRIPTION
ハードコードされているiPXE scriptのKernel parameterを変更できるようにしました。

- sabakanにkernel paramsを登録・取得するためのAPIを追加
- etcdにkernel paramsを登録・取得するための処理を追加
- etcdにkernel paramsのデータスキーマを仕様を決定
- sabactlにkernel paramsを登録・取得するコマンドを追加
- iPXEブート時に登録されたkernel paramsを含めてiPXE scriptの生成