### PR TITLE
store metadata for ignitions template

### DIFF
--- a/client/ignitions.go
+++ b/client/ignitions.go
@@ -7,7 +7,7 @@ import (
 	"path"
 )
 
-// IgnitionsGet gets ignition template ID list of the specified role
+// IgnitionsGet gets ignition template metadata list of the specified role
 func IgnitionsGet(ctx context.Context, role string) ([]map[string]string, *Status) {
 	var metadata []map[string]string
 	err := client.getJSON(ctx, "ignitions/"+role, nil, &metadata)

--- a/cmd/sabactl/assets.go
+++ b/cmd/sabactl/assets.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/cybozu-go/sabakan/client"
 	"github.com/google/subcommands"
-	"github.com/pkg/errors"
 )
 
 type assetsCmd struct{}
@@ -93,21 +90,6 @@ func assetsInfoCommand() subcommands.Command {
 		"get meta data of asset",
 		"info NAME",
 	}
-}
-
-type mapFlags map[string]string
-
-func (i *mapFlags) String() string {
-	return fmt.Sprint(*i)
-}
-
-func (i *mapFlags) Set(value string) error {
-	kv := strings.SplitN(value, "=", 2)
-	if len(kv) != 2 {
-		return errors.New("invalid options value: " + value)
-	}
-	(*i)[kv[0]] = kv[1]
-	return nil
 }
 
 type assetsUploadCmd struct {

--- a/cmd/sabactl/ignitions.go
+++ b/cmd/sabactl/ignitions.go
@@ -41,12 +41,12 @@ func (c ignitionsGetCmd) Execute(ctx context.Context, f *flag.FlagSet) subcomman
 		f.Usage()
 		return client.ExitUsageError
 	}
-	ids, status := client.IgnitionsGet(ctx, f.Arg(0))
+	metadata, status := client.IgnitionsGet(ctx, f.Arg(0))
 	if status != nil {
 		return handleError(status)
 	}
 
-	err := json.NewEncoder(os.Stdout).Encode(ids)
+	err := json.NewEncoder(os.Stdout).Encode(metadata)
 	return handleError(err)
 }
 
@@ -83,10 +83,12 @@ func ignitionsCatCommand() subcommands.Command {
 
 type ignitionsSetCmd struct {
 	file string
+	meta mapFlags
 }
 
 func (c *ignitionsSetCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&c.file, "f", "", "ignition template file")
+	f.Var(&c.meta, "meta", "optional metadata <KEY>=<VALUE>")
 }
 
 func (c *ignitionsSetCmd) Execute(ctx context.Context, f *flag.FlagSet) subcommands.ExitStatus {
@@ -95,13 +97,13 @@ func (c *ignitionsSetCmd) Execute(ctx context.Context, f *flag.FlagSet) subcomma
 		return client.ExitUsageError
 	}
 
-	err := client.IgnitionsSet(ctx, f.Arg(0), c.file)
+	err := client.IgnitionsSet(ctx, f.Arg(0), c.file, c.meta)
 	return handleError(err)
 }
 
 func ignitionsSetCommand() subcommands.Command {
 	return subcmd{
-		&ignitionsSetCmd{},
+		&ignitionsSetCmd{meta: mapFlags{}},
 		"set",
 		"create ignition template",
 		"set -f FILE ROLE ",

--- a/cmd/sabactl/map_flags.go
+++ b/cmd/sabactl/map_flags.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type mapFlags map[string]string
+
+func (i *mapFlags) String() string {
+	return fmt.Sprint(*i)
+}
+
+func (i *mapFlags) Set(value string) error {
+	kv := strings.SplitN(value, "=", 2)
+	if len(kv) != 2 {
+		return errors.New("invalid options value: " + value)
+	}
+	(*i)[kv[0]] = kv[1]
+	return nil
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -736,7 +736,7 @@ It returns a new assigned ID for the ignition.
 
 **Request headers**
 
-- `X-Sabakan-Ignition-<KEY>`: if given, the ignition will have meta data of `"<KEY>": "<VALUE>"`.
+- `X-Sabakan-Ignition-<KEY>`: if given, the ignition will have meta data of `"<Lowercased KEY>": "<VALUE>"`.
 
 **Successful response**
 

--- a/docs/ignition.md
+++ b/docs/ignition.md
@@ -19,7 +19,7 @@ In order to distribute CoreOS ignitions, sabakan provides an ignition management
 
 * Sabakan saves configured number of ignitions.
 
-    Sabakan deletes oldeh ignitions when operators upload a new ignition template.
+    Sabakan deletes older ignitions when operators upload a new ignition template.
 
 Sabakan also keeps metadata of each ignition other than `id` for external programs.
 
@@ -54,7 +54,9 @@ storage:
 The variables `sabakan` used in YAML are defined in [Machine](https://github.com/cybozu-go/sabakan/blob/d1a01d79307d3b3e188ff7a909204d71b5c2b9bb/machines.go#L12-L22) struct.
 The context of the template is the instance of the struct.
 For example, the YAML can refers serial number of the machine by `.Serial`.
-And the `MyURL` function can be used in YAML. The function will return the url of this sabakan server itself.
+And the `MyURL` and `Metadata` function can be used in YAML.
+`MyURL` function will return the url of this sabakan server itself.
+`Metadata` function will return the metadata of the key passed as an argument.
 
 User can set YAML files to sabakan via REST API `POST /api/v1/ignitions/ROLE` for each roles.
 The iPXE booted machine loads rendered ignitions in JSON via REST API `GET /api/v1/boot/coreos/ipxe/SERIAL`.
@@ -71,6 +73,8 @@ It is generated from YAML and source files as the following directory layout:
 |- files
 |   `- etc
 |       `- hostname
+|       `- ignitions
+|          `- version
 |- networkd
 |   `- 10-eno1.network
 `- passwd.yml
@@ -84,6 +88,7 @@ include: base.yml
 passwd: passwd.yml
 files:
   - /etc/hostname
+  - /etc/ignitions/version
 systemd:
   - enabled: false
     source: amyapp.service
@@ -107,6 +112,11 @@ The path must be *absolute path* and user need to put the source file in the `fi
 ```conf
 # files/etc/hostname
 {{ .Serial }}
+```
+
+```conf
+# files/etc/ignitions/version
+{{ Metadata "version" }}
 ```
 
 ```ini

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -60,12 +60,12 @@ or updated, the value will be incremented by one.
 This type of key holds the meta data of an asset.
 The value is described in [asset management](assets.md).
 
-`<prefix>/ignitions/<role>/<id>`
+`<prefix>/ignitions/template/<role>/<id>`
 -------------------------
 
 This type of key holds an ignition template. Ignitions are distinguished by `<role>`.
 
-`<prefix>/ignitions/<role>/<id>/meta`
+`<prefix>/ignitions/meta/<role>/<id>`
 -------------------------------------
 
 This type of key holds the meta data of an ignition template.

--- a/e2e/sabactl_test.go
+++ b/e2e/sabactl_test.go
@@ -473,14 +473,14 @@ func testSabactlIgnitions(t *testing.T) {
 	saved := `ignition:
   version: 2.2.0
 `
-	stdout, stderr, err := runSabactl("ignitions", "set", "-f", "../testdata/test/empty.yml", "cs")
+	stdout, stderr, err := runSabactl("ignitions", "set", "-f", "../testdata/test/empty.yml", "-meta", "version=20181010", "cs")
 	code := exitCode(err)
 	if code != client.ExitSuccess {
 		t.Log("stdout:", stdout.String())
 		t.Log("stderr:", stderr.String())
 		t.Fatal("failed to set ignition template", code)
 	}
-	stdout, stderr, err = runSabactl("ignitions", "set", "-f", "../testdata/test/test.yml", "cs")
+	stdout, stderr, err = runSabactl("ignitions", "set", "-f", "../testdata/test/test.yml", "-meta", "version=20181012", "cs")
 	code = exitCode(err)
 	if code != client.ExitSuccess {
 		t.Log("stdout:", stdout.String())
@@ -495,16 +495,22 @@ func testSabactlIgnitions(t *testing.T) {
 		t.Log("stderr:", stderr.String())
 		t.Fatal("failed to get ignition template IDs of cs", code)
 	}
-	var ids []string
-	err = json.NewDecoder(stdout).Decode(&ids)
+	var metadata []map[string]string
+	err = json.NewDecoder(stdout).Decode(&metadata)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ids) != 2 {
-		t.Error("expected:1, actual:", len(ids))
+	if len(metadata) != 2 {
+		t.Error("expected:1, actual:", len(metadata))
+	}
+	if metadata[0]["version"] != "20181010" {
+		t.Error("invalid metadata", metadata[0])
+	}
+	if metadata[1]["version"] != "20181012" {
+		t.Error("invalid metadata", metadata[1])
 	}
 
-	stdout, stderr, err = runSabactl("ignitions", "cat", "cs", ids[0])
+	stdout, stderr, err = runSabactl("ignitions", "cat", "cs", metadata[0]["id"])
 	code = exitCode(err)
 	if code != client.ExitSuccess {
 		t.Log("stdout:", stdout.String())
@@ -515,7 +521,7 @@ func testSabactlIgnitions(t *testing.T) {
 		t.Error("stdout.String() != saved", stdout.String())
 	}
 
-	stdout, stderr, err = runSabactl("ignitions", "delete", "cs", ids[0])
+	stdout, stderr, err = runSabactl("ignitions", "delete", "cs", metadata[0]["id"])
 	code = exitCode(err)
 	if code != client.ExitSuccess {
 		t.Log("stdout:", stdout.String())
@@ -530,13 +536,13 @@ func testSabactlIgnitions(t *testing.T) {
 		t.Log("stderr:", stderr.String())
 		t.Fatal("failed to get ignition template IDs of cs", code)
 	}
-	ids = []string{}
-	err = json.NewDecoder(stdout).Decode(&ids)
+	metadata = []map[string]string{}
+	err = json.NewDecoder(stdout).Decode(&metadata)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ids) != 1 {
-		t.Error("expected:1, actual:", len(ids))
+	if len(metadata) != 1 {
+		t.Error("expected:1, actual:", len(metadata))
 	}
 }
 

--- a/ignition.go
+++ b/ignition.go
@@ -19,7 +19,7 @@ const MaxIgnitions = 10
 // ValidateIgnitionTemplate validates if the tmpl is a template for a valid ignition.
 // The method returns nil if valid template is given, otherwise returns an error.
 // The method returns template by tmpl nil value of Machine.
-func ValidateIgnitionTemplate(tmpl string, ipam *IPAMConfig) error {
+func ValidateIgnitionTemplate(tmpl string, metadata map[string]string, ipam *IPAMConfig) error {
 	mc := NewMachine(MachineSpec{
 		Serial: "1234abcd",
 		Rack:   1,
@@ -30,7 +30,7 @@ func ValidateIgnitionTemplate(tmpl string, ipam *IPAMConfig) error {
 	}
 
 	ipam.GenerateIP(mc)
-	ign, err := RenderIgnition(tmpl, mc, u)
+	ign, err := RenderIgnition(tmpl, metadata, mc, u)
 
 	if err != nil {
 		return err
@@ -46,12 +46,15 @@ func ValidateIgnitionTemplate(tmpl string, ipam *IPAMConfig) error {
 }
 
 // RenderIgnition returns the rendered ignition from the template and a machine
-func RenderIgnition(tmpl string, m *Machine, myURL *url.URL) (string, error) {
+func RenderIgnition(tmpl string, metadata map[string]string, m *Machine, myURL *url.URL) (string, error) {
 	getMyURL := func() string {
 		return myURL.String()
 	}
+	getMetadata := func(key string) string {
+		return metadata[key]
+	}
 	t, err := template.New("ignition").
-		Funcs(template.FuncMap{"MyURL": getMyURL}).
+		Funcs(template.FuncMap{"MyURL": getMyURL, "Metadata": getMetadata}).
 		Parse(tmpl)
 	if err != nil {
 		return "", err

--- a/ignition_test.go
+++ b/ignition_test.go
@@ -36,7 +36,7 @@ storage:
       source: "{{.Serial}}"`,
 	}
 	for _, tmpl := range tmpls {
-		err := ValidateIgnitionTemplate(tmpl, testIPAMConfig)
+		err := ValidateIgnitionTemplate(tmpl, nil, testIPAMConfig)
 		if err != nil {
 			t.Error("err != nil:", err)
 		}
@@ -57,7 +57,7 @@ storage:
 	}
 
 	for _, tmpl := range tmpls {
-		err := ValidateIgnitionTemplate(tmpl, testIPAMConfig)
+		err := ValidateIgnitionTemplate(tmpl, nil, testIPAMConfig)
 		if err == nil {
 			t.Error("err == nil:", err)
 		}
@@ -84,17 +84,23 @@ storage:
       user:
         id: 500
       group:
-        id: 501`,
+        id: 501
+    - path: /etc/ignitions/version
+      contents:
+        source: '{{Metadata "version"}}'`,
 			NewMachine(MachineSpec{Serial: "abcd, 1234"}),
-			`{"ignition":{"version":"2.2.0"},"storage":{"files":[{"filesystem":"root","group":{"id":501},"path":"/opt/file1","user":{"id":500},"contents":{"source":"data:,abcd%2C%201234"},"mode":420}]}}`},
+			`{"ignition":{"version":"2.2.0"},"storage":{"files":[{"filesystem":"root","group":{"id":501},"path":"/opt/file1","user":{"id":500},"contents":{"source":"data:,abcd%2C%201234"},"mode":420},{"contents":{"source":"data:,20181010"},"path":"/etc/ignitions/version"}]}}`},
 	}
 	u, err := url.Parse("http://localhost:10080")
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	metadata := map[string]string{
+		"version": "20181010",
+	}
 	for _, c := range cases {
-		ign, err := RenderIgnition(c.tmpl, c.mc, u)
+		ign, err := RenderIgnition(c.tmpl, metadata, c.mc, u)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/model.go
+++ b/model.go
@@ -85,9 +85,10 @@ type AssetModel interface {
 
 // IgnitionModel is an interface for ignition template.
 type IgnitionModel interface {
-	PutTemplate(ctx context.Context, role string, template string) (string, error)
-	GetTemplateIDs(ctx context.Context, role string) ([]string, error)
+	PutTemplate(ctx context.Context, role string, template string, metadata map[string]string) (string, error)
+	GetTemplateMetadataList(ctx context.Context, role string) ([]map[string]string, error)
 	GetTemplate(ctx context.Context, role string, id string) (string, error)
+	GetTemplateMetadata(ctx context.Context, role string, id string) (map[string]string, error)
 	DeleteTemplate(ctx context.Context, role string, id string) error
 }
 

--- a/models/etcd/constants.go
+++ b/models/etcd/constants.go
@@ -4,19 +4,20 @@ import "time"
 
 // Internal schema keys.
 const (
-	KeyCrypts       = "crypts/"
-	KeyDHCP         = "dhcp"
-	KeyIPAM         = "ipam"
-	KeyLeaseUsages  = "lease-usages/"
-	KeyMachines     = "machines/"
-	KeyNodeIndices  = "node-indices/"
-	KeyImages       = "images/"
-	KeyAssets       = "assets/"
-	KeyAssetsID     = "assets"
-	KeyIgnitions    = "ignitions/"
-	KeyAudit        = "audit/"
-	KeyAuditLastGC  = "audit"
-	KeyKernelParams = "kernel-params/"
+	KeyCrypts            = "crypts/"
+	KeyDHCP              = "dhcp"
+	KeyIPAM              = "ipam"
+	KeyLeaseUsages       = "lease-usages/"
+	KeyMachines          = "machines/"
+	KeyNodeIndices       = "node-indices/"
+	KeyImages            = "images/"
+	KeyAssets            = "assets/"
+	KeyAssetsID          = "assets"
+	KeyIgnitionsTemplate = "ignitions/templates/"
+	KeyIgnitionsMetadata = "ignitions/meta/"
+	KeyAudit             = "audit/"
+	KeyAuditLastGC       = "audit"
+	KeyKernelParams      = "kernel-params/"
 )
 
 // MaxDeleted is the maximum number of deleted image IDs stored in etcd.

--- a/models/etcd/ignition.go
+++ b/models/etcd/ignition.go
@@ -20,7 +20,7 @@ RETRY:
 	id := strconv.FormatInt(now.UnixNano(), 10)
 	target := path.Join(KeyIgnitionsTemplate, role, id)
 	meta := path.Join(KeyIgnitionsMetadata, role, id)
-	metaJson, err := json.Marshal(metadata)
+	metaJSON, err := json.Marshal(metadata)
 	if err != nil {
 		return "", err
 	}
@@ -28,7 +28,7 @@ RETRY:
 	tresp, err := d.client.Txn(ctx).
 		// Prohibit overwriting
 		If(clientv3util.KeyMissing(target), clientv3util.KeyMissing(meta)).
-		Then(clientv3.OpPut(target, template), clientv3.OpPut(meta, string(metaJson))).
+		Then(clientv3.OpPut(target, template), clientv3.OpPut(meta, string(metaJSON))).
 		Else().
 		Commit()
 	if err != nil {

--- a/models/etcd/ignition.go
+++ b/models/etcd/ignition.go
@@ -11,10 +11,14 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/clientv3util"
 	"github.com/cybozu-go/sabakan"
+	"github.com/pkg/errors"
 )
 
 // PutTemplate implements sabakan.IgnitionModel
 func (d *driver) PutTemplate(ctx context.Context, role string, template string, metadata map[string]string) (string, error) {
+	if metadata == nil {
+		return "", errors.New("metadata should not be nil")
+	}
 RETRY:
 	now := time.Now()
 	id := strconv.FormatInt(now.UnixNano(), 10)
@@ -97,14 +101,12 @@ func (d *driver) GetTemplateMetadataList(ctx context.Context, role string) ([]ma
 
 	metadata := make([]map[string]string, len(resp.Kvs))
 	for i, v := range resp.Kvs {
-		id := string(v.Key[len(target):])
-		meta := map[string]string{
-			"id": id,
-		}
+		meta := make(map[string]string)
 		err = json.Unmarshal(v.Value, &meta)
 		if err != nil {
 			return nil, err
 		}
+		meta["id"] = string(v.Key[len(target):])
 		metadata[i] = meta
 	}
 

--- a/models/etcd/ignition.go
+++ b/models/etcd/ignition.go
@@ -2,6 +2,7 @@ package etcd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path"
 	"strconv"
@@ -13,16 +14,21 @@ import (
 )
 
 // PutTemplate implements sabakan.IgnitionModel
-func (d *driver) PutTemplate(ctx context.Context, role string, template string) (string, error) {
+func (d *driver) PutTemplate(ctx context.Context, role string, template string, metadata map[string]string) (string, error) {
 RETRY:
 	now := time.Now()
 	id := strconv.FormatInt(now.UnixNano(), 10)
-	target := path.Join(KeyIgnitions, role, id)
+	target := path.Join(KeyIgnitionsTemplate, role, id)
+	meta := path.Join(KeyIgnitionsMetadata, role, id)
+	metaJson, err := json.Marshal(metadata)
+	if err != nil {
+		return "", err
+	}
 
 	tresp, err := d.client.Txn(ctx).
 		// Prohibit overwriting
-		If(clientv3util.KeyMissing(target)).
-		Then(clientv3.OpPut(target, template)).
+		If(clientv3util.KeyMissing(target), clientv3util.KeyMissing(meta)).
+		Then(clientv3.OpPut(target, template), clientv3.OpPut(meta, string(metaJson))).
 		Else().
 		Commit()
 	if err != nil {
@@ -37,8 +43,8 @@ RETRY:
 	d.addLog(ctx, now, tresp.Header.Revision, sabakan.AuditIgnition, role, "put",
 		fmt.Sprintf("id=%s\n%s", id, template))
 
-	prefix := path.Join(KeyIgnitions, role) + "/"
-	resp, err := d.client.Get(ctx, prefix,
+	tmplPrefix := path.Join(KeyIgnitionsTemplate, role) + "/"
+	resp, err := d.client.Get(ctx, tmplPrefix,
 		clientv3.WithPrefix(),
 		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
 	if err != nil {
@@ -47,9 +53,26 @@ RETRY:
 	if resp.Count <= sabakan.MaxIgnitions {
 		return id, nil
 	}
-	end := string(resp.Kvs[resp.Count-sabakan.MaxIgnitions].Key)
-	_, err = d.client.Delete(ctx, prefix,
-		clientv3.WithRange(end))
+	tmplEnd := string(resp.Kvs[resp.Count-sabakan.MaxIgnitions].Key)
+
+	metaPrefix := path.Join(KeyIgnitionsMetadata, role) + "/"
+	resp, err = d.client.Get(ctx, metaPrefix,
+		clientv3.WithPrefix(),
+		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
+	if err != nil {
+		return "", err
+	}
+	if resp.Count <= sabakan.MaxIgnitions {
+		return id, nil
+	}
+	metaEnd := string(resp.Kvs[resp.Count-sabakan.MaxIgnitions].Key)
+
+	tresp, err = d.client.Txn(ctx).
+		Then(
+			clientv3.OpDelete(tmplPrefix, clientv3.WithRange(tmplEnd)),
+			clientv3.OpDelete(metaPrefix, clientv3.WithRange(metaEnd)),
+		).
+		Commit()
 	if err != nil {
 		return "", err
 	}
@@ -57,9 +80,9 @@ RETRY:
 	return id, nil
 }
 
-// GetTemplateIDs implements sabakan.IgnitionModel
-func (d *driver) GetTemplateIDs(ctx context.Context, role string) ([]string, error) {
-	target := path.Join(KeyIgnitions, role) + "/"
+// GetTemplateMetadataList implements sabakan.IgnitionModel
+func (d *driver) GetTemplateMetadataList(ctx context.Context, role string) ([]map[string]string, error) {
+	target := path.Join(KeyIgnitionsMetadata, role) + "/"
 	resp, err := d.client.Get(ctx, target,
 		clientv3.WithPrefix(),
 		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
@@ -72,18 +95,25 @@ func (d *driver) GetTemplateIDs(ctx context.Context, role string) ([]string, err
 		return nil, sabakan.ErrNotFound
 	}
 
-	ids := make([]string, len(resp.Kvs))
+	metadata := make([]map[string]string, len(resp.Kvs))
 	for i, v := range resp.Kvs {
-		id := v.Key[len(target):]
-		ids[i] = string(id)
+		id := string(v.Key[len(target):])
+		meta := map[string]string{
+			"id": id,
+		}
+		err = json.Unmarshal(v.Value, &meta)
+		if err != nil {
+			return nil, err
+		}
+		metadata[i] = meta
 	}
 
-	return ids, nil
+	return metadata, nil
 }
 
 // GetTemplate implements sabakan.IgnitionModel
 func (d *driver) GetTemplate(ctx context.Context, role string, id string) (string, error) {
-	target := path.Join(KeyIgnitions, role, id)
+	target := path.Join(KeyIgnitionsTemplate, role, id)
 	resp, err := d.client.Get(ctx, target)
 	if err != nil {
 		return "", err
@@ -96,19 +126,44 @@ func (d *driver) GetTemplate(ctx context.Context, role string, id string) (strin
 	return string(resp.Kvs[0].Value), nil
 }
 
+// GetTemplateMetadata implements sabakan.IgnitionModel
+func (d *driver) GetTemplateMetadata(ctx context.Context, role string, id string) (map[string]string, error) {
+	target := path.Join(KeyIgnitionsMetadata, role, id)
+	resp, err := d.client.Get(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Count == 0 {
+		return nil, sabakan.ErrNotFound
+	}
+	var metadata map[string]string
+	err = json.Unmarshal(resp.Kvs[0].Value, &metadata)
+	if err != nil {
+		return nil, err
+	}
+	return metadata, nil
+}
+
 // DeleteTemplate implements sabakan.IgnitionModel
 func (d *driver) DeleteTemplate(ctx context.Context, role string, id string) error {
-	target := path.Join(KeyIgnitions, role, id)
-	resp, err := d.client.Delete(ctx, target)
+	tmplTarget := path.Join(KeyIgnitionsTemplate, role, id)
+	metaTarget := path.Join(KeyIgnitionsMetadata, role, id)
+	tresp, err := d.client.Txn(ctx).
+		Then(
+			clientv3.OpDelete(tmplTarget),
+			clientv3.OpDelete(metaTarget),
+		).
+		Commit()
 	if err != nil {
 		return err
 	}
 
-	if resp.Deleted == 0 {
+	if tresp.Responses[0].GetResponseDeleteRange().Deleted == 0 || tresp.Responses[1].GetResponseDeleteRange().Deleted == 0 {
 		return sabakan.ErrNotFound
 	}
 
-	d.addLog(ctx, time.Now(), resp.Header.Revision, sabakan.AuditIgnition, role, "delete", id)
+	d.addLog(ctx, time.Now(), tresp.Header.Revision, sabakan.AuditIgnition, role, "delete", id)
 
 	return nil
 }

--- a/models/etcd/ignition_test.go
+++ b/models/etcd/ignition_test.go
@@ -18,7 +18,7 @@ func testTemplate(t *testing.T) {
 		t.Fatal("unexpected error: ", err)
 	}
 
-	id, err := d.PutTemplate(context.Background(), "cs", "data", nil)
+	id, err := d.PutTemplate(context.Background(), "cs", "data", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func testTemplate(t *testing.T) {
 	}
 }
 
-func testTemplateIDs(t *testing.T) {
+func testTemplateMetadata(t *testing.T) {
 	t.Parallel()
 
 	d, _ := testNewDriver(t)
@@ -73,7 +73,7 @@ func testTemplateIDs(t *testing.T) {
 	}
 
 	for i := 0; i < sabakan.MaxIgnitions+10; i++ {
-		_, err = d.PutTemplate(context.Background(), "cs", "data", nil)
+		_, err = d.PutTemplate(context.Background(), "cs", "data", map[string]string{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -85,10 +85,15 @@ func testTemplateIDs(t *testing.T) {
 	if len(metadata) != sabakan.MaxIgnitions {
 		t.Error("wrong number of templates", len(metadata))
 	}
+	for _, m := range metadata {
+		if len(m["id"]) == 0 {
+			t.Error("id is empty")
+		}
+	}
 
 }
 
 func TestIgnitionTemplate(t *testing.T) {
 	t.Run("Template", testTemplate)
-	t.Run("TemplateIDs", testTemplateIDs)
+	t.Run("TemplateIDs", testTemplateMetadata)
 }

--- a/models/etcd/ignition_test.go
+++ b/models/etcd/ignition_test.go
@@ -2,6 +2,7 @@ package etcd
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cybozu-go/sabakan"
@@ -17,7 +18,7 @@ func testTemplate(t *testing.T) {
 		t.Fatal("unexpected error: ", err)
 	}
 
-	id, err := d.PutTemplate(context.Background(), "cs", "data")
+	id, err := d.PutTemplate(context.Background(), "cs", "data", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,36 +47,43 @@ func testTemplateIDs(t *testing.T) {
 
 	d, _ := testNewDriver(t)
 
-	_, err := d.GetTemplateIDs(context.Background(), "cs")
+	_, err := d.GetTemplateMetadataList(context.Background(), "cs")
 	if err != sabakan.ErrNotFound {
 		t.Fatal("unexpected error: ", err)
 	}
 
-	_, err = d.PutTemplate(context.Background(), "cs", "data")
+	_, err = d.PutTemplate(context.Background(), "cs", "data", map[string]string{"version": "20181010"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ids, err := d.GetTemplateIDs(context.Background(), "cs")
+	metadata, err := d.GetTemplateMetadataList(context.Background(), "cs")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ids) != 1 {
-		t.Error("wrong number of templates", len(ids))
+	if len(metadata) != 1 {
+		t.Error("wrong number of templates", len(metadata))
+		fmt.Println(metadata)
+	}
+	if len(metadata[0]["id"]) == 0 {
+		t.Error("id is empty")
+	}
+	if metadata[0]["version"] != "20181010" {
+		t.Error("wrong version", metadata[0])
 	}
 
 	for i := 0; i < sabakan.MaxIgnitions+10; i++ {
-		_, err = d.PutTemplate(context.Background(), "cs", "data")
+		_, err = d.PutTemplate(context.Background(), "cs", "data", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
-	ids, err = d.GetTemplateIDs(context.Background(), "cs")
+	metadata, err = d.GetTemplateMetadataList(context.Background(), "cs")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ids) != sabakan.MaxIgnitions {
-		t.Error("wrong number of templates", len(ids))
+	if len(metadata) != sabakan.MaxIgnitions {
+		t.Error("wrong number of templates", len(metadata))
 	}
 
 }

--- a/web/coreos.go
+++ b/web/coreos.go
@@ -86,7 +86,7 @@ func (s Server) handleCoreOSiPXEWithSerial(w http.ResponseWriter, r *http.Reques
 
 	u := *s.MyURL
 	u.Path = path.Join("/api/v1/boot")
-	ipxe := fmt.Sprintf(coreOSiPXETemplate, u.String(), metadata[len(metadata)-1], params)
+	ipxe := fmt.Sprintf(coreOSiPXETemplate, u.String(), metadata[len(metadata)-1]["id"], params)
 
 	w.Header().Set("Content-Type", "text/plain; charset=ASCII")
 	w.Write([]byte(ipxe))

--- a/web/coreos.go
+++ b/web/coreos.go
@@ -68,7 +68,7 @@ func (s Server) handleCoreOSiPXEWithSerial(w http.ResponseWriter, r *http.Reques
 	}
 
 	role := m.Spec.Role
-	ids, err := s.Model.Ignition.GetTemplateIDs(r.Context(), role)
+	metadata, err := s.Model.Ignition.GetTemplateMetadataList(r.Context(), role)
 	if err == sabakan.ErrNotFound {
 		renderError(r.Context(), w, APIErrNotFound)
 		return
@@ -86,7 +86,7 @@ func (s Server) handleCoreOSiPXEWithSerial(w http.ResponseWriter, r *http.Reques
 
 	u := *s.MyURL
 	u.Path = path.Join("/api/v1/boot")
-	ipxe := fmt.Sprintf(coreOSiPXETemplate, u.String(), ids[len(ids)-1], params)
+	ipxe := fmt.Sprintf(coreOSiPXETemplate, u.String(), metadata[len(metadata)-1], params)
 
 	w.Header().Set("Content-Type", "text/plain; charset=ASCII")
 	w.Write([]byte(ipxe))

--- a/web/coreos_test.go
+++ b/web/coreos_test.go
@@ -75,7 +75,7 @@ func testHandleiPXEWithSerial(t *testing.T) {
 		t.Error("resp.StatusCode != http.StatusNotFound:", resp.StatusCode)
 	}
 
-	_, err = m.Ignition.PutTemplate(context.Background(), "cs", ign)
+	_, err = m.Ignition.PutTemplate(context.Background(), "cs", ign, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/coreos_test.go
+++ b/web/coreos_test.go
@@ -75,7 +75,7 @@ func testHandleiPXEWithSerial(t *testing.T) {
 		t.Error("resp.StatusCode != http.StatusNotFound:", resp.StatusCode)
 	}
 
-	_, err = m.Ignition.PutTemplate(context.Background(), "cs", ign, nil)
+	_, err = m.Ignition.PutTemplate(context.Background(), "cs", ign, map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/ignitions_test.go
+++ b/web/ignitions_test.go
@@ -81,7 +81,7 @@ networkd:
 	m := mock.NewModel()
 	handler := Server{Model: m}
 
-	_, err := m.Ignition.PutTemplate(context.Background(), "cs", ign)
+	_, err := m.Ignition.PutTemplate(context.Background(), "cs", ign, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,7 @@ networkd:
 	}
 }
 
-func testIgnitionTemplateIDsGet(t *testing.T) {
+func testIgnitionTemplateMetadataGet(t *testing.T) {
 	t.Parallel()
 
 	m := mock.NewModel()
@@ -164,11 +164,11 @@ func testIgnitionTemplateIDsGet(t *testing.T) {
 		t.Error("resp.StatusCode != http.StatusNotFound:", resp.StatusCode)
 	}
 
-	_, err := m.Ignition.PutTemplate(context.Background(), "cs", "hoge")
+	_, err := m.Ignition.PutTemplate(context.Background(), "cs", "hoge", map[string]string{"version": "1.2.3"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = m.Ignition.PutTemplate(context.Background(), "cs", "fuga")
+	_, err = m.Ignition.PutTemplate(context.Background(), "cs", "fuga", map[string]string{"version": "3.4.5"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,10 +181,22 @@ func testIgnitionTemplateIDsGet(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatal("resp.StatusCode != http.StatusOK:", resp.StatusCode)
 	}
-	var data []string
+	var data []map[string]string
 	err = json.NewDecoder(resp.Body).Decode(&data)
 	if len(data) != 2 {
 		t.Error("len(data) != 2:", len(data))
+	}
+	if len(data[0]["id"]) == 0 {
+		t.Error("id is empty")
+	}
+	if len(data[1]["id"]) == 0 {
+		t.Error("id is empty")
+	}
+	if data[0]["version"] != "1.2.3" {
+		t.Error("wrong version: ", data[0])
+	}
+	if data[1]["version"] != "3.4.5" {
+		t.Error("wrong version: ", data[1])
 	}
 }
 
@@ -203,7 +215,7 @@ func testIgnitionTemplatesGet(t *testing.T) {
 		t.Error("resp.StatusCode != http.StatusNotFound:", resp.StatusCode)
 	}
 
-	_, err := m.Ignition.PutTemplate(context.Background(), "cs", "hoge")
+	_, err := m.Ignition.PutTemplate(context.Background(), "cs", "hoge", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +316,7 @@ func testIgnitionTemplatesDelete(t *testing.T) {
 	m := mock.NewModel()
 	handler := newTestServer(m)
 
-	_, err := m.Ignition.PutTemplate(context.Background(), "cs", "hello")
+	_, err := m.Ignition.PutTemplate(context.Background(), "cs", "hello", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -338,7 +350,7 @@ func testIgnitionTemplatesDelete(t *testing.T) {
 }
 
 func TestIgnitionTemplates(t *testing.T) {
-	t.Run("TemplateIDsGet", testIgnitionTemplateIDsGet)
+	t.Run("TemplateMetadataGet", testIgnitionTemplateMetadataGet)
 	t.Run("TemplatesGet", testIgnitionTemplatesGet)
 	t.Run("TemplatePost", testIgnitionTemplatesPost)
 	t.Run("TemplateDelete", testIgnitionTemplatesDelete)

--- a/web/ignitions_test.go
+++ b/web/ignitions_test.go
@@ -81,7 +81,7 @@ networkd:
 	m := mock.NewModel()
 	handler := Server{Model: m}
 
-	_, err := m.Ignition.PutTemplate(context.Background(), "cs", ign, nil)
+	_, err := m.Ignition.PutTemplate(context.Background(), "cs", ign, map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func testIgnitionTemplatesGet(t *testing.T) {
 		t.Error("resp.StatusCode != http.StatusNotFound:", resp.StatusCode)
 	}
 
-	_, err := m.Ignition.PutTemplate(context.Background(), "cs", "hoge", nil)
+	_, err := m.Ignition.PutTemplate(context.Background(), "cs", "hoge", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +316,7 @@ func testIgnitionTemplatesDelete(t *testing.T) {
 	m := mock.NewModel()
 	handler := newTestServer(m)
 
-	_, err := m.Ignition.PutTemplate(context.Background(), "cs", "hello", nil)
+	_, err := m.Ignition.PutTemplate(context.Background(), "cs", "hello", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
 * add `-meta` options to `sabactl ignition set` subcommand.
 * add metadata in request header of put ignitions template API.
 * add `Metadata` function to render ignitions template.