### PR TITLE
Validate label names and values samely as Kubernetes

### DIFF
--- a/machines.go
+++ b/machines.go
@@ -48,15 +48,14 @@ const (
 )
 
 var (
-	reValidRole      = regexp.MustCompile(`^[a-zA-Z][0-9a-zA-Z._-]*$`)
 	reValidBmcType   = regexp.MustCompile(`^[a-z0-9A-Z-_/.]+$`)
-	reValidLabelVal  = regexp.MustCompile(`^[[:print:]]+$`)
-	reValidLabelName = regexp.MustCompile(`^[a-z0-9A-Z-_/.]+$`)
+	reValidLabelName = regexp.MustCompile(`^[a-z0-9A-Z]([a-z0-9A-Z_.-]{0,61}[a-z0-9A-Z])?$`)
+	reValidLabelVal  = regexp.MustCompile(`^[a-z0-9A-Z]([a-z0-9A-Z_.-]{0,61}[a-z0-9A-Z])?$`)
 )
 
 // IsValidRole returns true if role is valid as machine role
 func IsValidRole(role string) bool {
-	return reValidRole.MatchString(role)
+	return reValidLabelVal.MatchString(role)
 }
 
 // IsValidBmcType returns true if role is valid as BMC type
@@ -65,12 +64,17 @@ func IsValidBmcType(bmcType string) bool {
 }
 
 // IsValidLabelName returns true if label name is valid
+// This is the same as the validation for Kubernetes label names.
 func IsValidLabelName(name string) bool {
 	return reValidLabelName.MatchString(name)
 }
 
 // IsValidLabelValue returns true if label value is valid
+// This is the same as the validation for Kubernetes label values.
 func IsValidLabelValue(value string) bool {
+	if value == "" {
+		return true
+	}
 	return reValidLabelVal.MatchString(value)
 }
 

--- a/machines_test.go
+++ b/machines_test.go
@@ -42,13 +42,13 @@ func TestIsValidBmcType(t *testing.T) {
 func TestIsValidLabelName(t *testing.T) {
 	t.Parallel()
 
-	validNames := []string{"valid_name1", "valid-name2", "valid/name3"}
+	validNames := []string{"valid_name1", "valid-n.ame2"}
 	for _, vn := range validNames {
 		if !IsValidLabelName(vn) {
 			t.Error("validator should return true:", vn)
 		}
 	}
-	invalidNames := []string{"^in;valid name\\1", "in$valid#name&2", "invalid@name=3"}
+	invalidNames := []string{"^in;valid name\\1", "in$valid#name&2", "invalid@name=3", "invalid/name3"}
 	for _, ivn := range invalidNames {
 		if IsValidLabelName(ivn) {
 			t.Error("validator should return false:", ivn)
@@ -59,7 +59,7 @@ func TestIsValidLabelName(t *testing.T) {
 func TestIsValidLabelValue(t *testing.T) {
 	t.Parallel()
 
-	validVals := []string{"^valid value@1", "valid$value-=2", "%valid':value;3"}
+	validVals := []string{"validvalue1", "valid.value-_2"}
 	for _, vv := range validVals {
 		if !IsValidLabelValue(vv) {
 			t.Error("validator should return true:", vv)


### PR DESCRIPTION
For integration with CKE, machine labels are need to be valid
as the same way as Kubernetes.  The role value also need to be
vaild label value.

Kubernetes syntax is described at
https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set