### PR TITLE
Fix sabactl ignitions command error

### DIFF
--- a/pkg/sabactl/cmd/ignitions.go
+++ b/pkg/sabactl/cmd/ignitions.go
@@ -68,6 +68,7 @@ var ignitionsCatCmd = &cobra.Command{
 	Use:   "cat ROLE ID",
 	Short: "show the ignition template",
 	Long:  `Show the ignition template for the ID and ROLE.`,
+	Args:  cobra.ExactArgs(2),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		role, id := args[0], args[1]
@@ -83,6 +84,7 @@ var ignitionsDeleteCmd = &cobra.Command{
 	Use:   "delete ROLE ID",
 	Short: "delete an ignition template",
 	Long:  `Delete an ignition template for the ID and ROLE.`,
+	Args:  cobra.ExactArgs(2),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		role, id := args[0], args[1]


### PR DESCRIPTION
Fix following error
```
$ sabactl ignitions cat
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/cybozu-go/sabakan/pkg/sabactl/cmd.glob..func10(0xc409e0, 0xc6b4d8, 0x0, 0x0, 0x0, 0x0)
        /work/pkg/sabactl/cmd/ignitions.go:73 +0x12c
github.com/spf13/cobra.(*Command).execute(0xc409e0, 0xc6b4d8, 0x0, 0x0, 0xc409e0, 0xc6b4d8)
        /go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:762 +0x473
github.com/spf13/cobra.(*Command).ExecuteC(0xc43e20, 0xc00023df88, 0x407440, 0xc000074058)
        /go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852 +0x2fd
github.com/spf13/cobra.(*Command).Execute(0xc43e20, 0x0, 0x0)
        /go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800 +0x2b
github.com/cybozu-go/sabakan/pkg/sabactl/cmd.Execute()
        /work/pkg/sabactl/cmd/root.go:65 +0x31
main.main()
        /work/pkg/sabactl/main.go:8 +0x20
```