### PR TITLE
[ignition] add "remote_files" to template.

### DIFF
--- a/client/ignition_template_test.go
+++ b/client/ignition_template_test.go
@@ -24,8 +24,8 @@ func testBuildIgnitionTemplate2_3(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tmpl.Version != Ignition2_2 {
-		t.Error(`tmpl.Version != Ignition2_2:`, tmpl.Version)
+	if tmpl.Version != Ignition2_3 {
+		t.Error(`tmpl.Version != Ignition2_3:`, tmpl.Version)
 	}
 	if !cmp.Equal(meta, tmpl.Metadata) {
 		t.Error("wrong meta data:", cmp.Diff(meta, tmpl.Metadata))
@@ -54,11 +54,13 @@ func testBuildIgnitionTemplate2_3(t *testing.T) {
 			SSHAuthorizedKeys: []ign23.SSHAuthorizedKey{"key1"},
 		},
 	}
-	expectedFiles := make([]ign23.File, 2)
+	expectedFiles := make([]ign23.File, 3)
 	expectedFiles[0].Path = "/etc/rack"
 	expectedFiles[0].Contents.Source = "data:," + dataurl.EscapeString("{{ .Spec.Rack }}\n")
-	expectedFiles[1].Path = "/etc/hostname"
-	expectedFiles[1].Contents.Source = "data:," + dataurl.EscapeString("{{ .Spec.Serial }}\n")
+	expectedFiles[1].Path = "/tmp/foo.img"
+	expectedFiles[1].Contents.Source = "{{ MyURL }}/api/v1/assets/foo.img"
+	expectedFiles[2].Path = "/etc/hostname"
+	expectedFiles[2].Contents.Source = "data:," + dataurl.EscapeString("{{ .Spec.Serial }}\n")
 	expected.Storage.Files = expectedFiles
 	expected.Networkd.Units = []ign23.Networkdunit{
 		{

--- a/docs/api.md
+++ b/docs/api.md
@@ -762,11 +762,11 @@ Upload an Ignition template for `<role>` with `<id>`.
 
 The request body must be a JSON object with these fields:
 
-| Name       | Type   | Description                                                                         |
-| ---------- | ------ | ----------------------------------------------------------------------------------- |
-| `version`  | string | Ignition configuration specification as `major.minor`.                              |
-| `template` | object | An ignition configuration to be rendered as desribed in [ignition.md](ignition.md). |
-| `meta`     | object | Meta data associated with this template.                                            |
+| Name       | Type   | Description                                                                                           |
+| ---------- | ------ | ----------------------------------------------------------------------------------------------------- |
+| `version`  | string | Ignition configuration specification as `major.minor`.                                                |
+| `template` | object | An ignition configuration to be rendered as desribed in [ignition_template.md](ignition_template.md). |
+| `meta`     | object | Meta data associated with this template.                                                              |
 
 The currently supported ignition specifications are: `2.3`.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -164,7 +164,7 @@ CoreOS Container Linux using [UEFI HTTP Boot][HTTPBoot].
 
 CoreOS can be initialized at first boot by [ignition][].
 Sabakan can generate ignition configuration from templates.
-Read [ignition.md](ignition.md) for details.
+Read [ignition_template.md](ignition_template.md) for details.
 
 ### <a name="kernelparams" />Register kernel parameters
 

--- a/docs/ignition_template.md
+++ b/docs/ignition_template.md
@@ -18,6 +18,9 @@ include: ../base/base.yml
 passwd: passwd.yml
 files:
   - /etc/hostname
+remote_files:
+  - name: /tmp/some.img
+    url: "{{ MyURL }}/v1/assets/some.img"
 systemd:
   - name: chronyd.service
     enabled: true
@@ -32,10 +35,10 @@ Field descriptions:
     * "2.2" (default)
     * "2.3"
 * `include`: Another ignition template to be included.
-* `passwd`: A filename in the same directory of the template.  
-    The contents should be a YAML encoded ignition's [`passwd` object](https://coreos.com/ignition/docs/latest/configuration-v2_3.html).
+* `passwd`: A YAML filename that contains YAML encoded ignition's [`passwd` object](https://coreos.com/ignition/docs/latest/configuration-v2_3.html).
 * `files`: List of filenames to be provisioned.  
     The file contents are read from files under `files/` sub directory.
+* `remote_files`: List of remote files to be provisioned.
 * `systemd`: List of systemd unit files to be provisioned.  
     The unit contents are read from files under `systemd/` sub directory.  
     If `enabled` is true, the unit will be enabled.  
@@ -46,6 +49,7 @@ Field descriptions:
 ### Rendering specifications
 
 Files pointed by the template YAML are rendered by [text/template][].
+Strings in `passwd` YAML and `url` for `remote_files` are also rendered as templates.
 
 `.` in the template is set to the [`Machine`](machine.md#machine-struct) struct of the target machine.  
 For example, `{{ .Spec.Serial }}` will be replaced with the serial number of the target machine.

--- a/docs/sabactl.md
+++ b/docs/sabactl.md
@@ -212,7 +212,7 @@ If `ID` is specified, the command outputs a JSON object like this:
 Register a new ignition template for `ROLE` with `ID`.
 For details, see .
 
-`FILE` is either a template YAML described in [Ignition Templates](ignition.md), or
+`FILE` is either a template YAML described in [Ignition Templates](ignition_template.md), or
 a JSON got by `sabactl ignitions get ROLE ID` if `--json` is given.
 
 A template can be associated with meta data if `--meta FILENAME` is given.

--- a/testdata/base/base.yml
+++ b/testdata/base/base.yml
@@ -1,6 +1,10 @@
+version: "2.3"
 passwd: passwd.yml
 files:
   - /etc/rack
+remote_files:
+  - name: /tmp/foo.img
+    url: "{{ MyURL }}/api/v1/assets/foo.img"
 systemd:
   - name: chronyd.service
     enabled: true

--- a/testdata/test/test.yml
+++ b/testdata/test/test.yml
@@ -1,3 +1,4 @@
+version: "2.3"
 include: ../base/base.yml
 files:
   - /etc/hostname


### PR DESCRIPTION
Ignition can download file contents from remote servers.

This commit enhances ignition template YAML to use this feature
by adding "remote_files" directive.