### PR TITLE
[ignition] add mandatory properties for files

### DIFF
--- a/client/ignition_template.go
+++ b/client/ignition_template.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -25,6 +26,7 @@ type SystemdUnit struct {
 type RemoteFile struct {
 	Name string `json:"name"`
 	URL  string `json:"url"`
+	Mode *int   `json:"mode"`
 }
 
 // TemplateSource represents YAML/JSON source file of Ignition template.
@@ -154,9 +156,16 @@ func buildTemplate2_2(src *TemplateSource, baseDir string) (*ign22.Config, error
 		if err != nil {
 			return nil, err
 		}
+		fi, err := os.Stat(target)
+		if err != nil {
+			return nil, err
+		}
 		var file ign22.File
+		file.Filesystem = "root"
 		file.Path = fname
 		file.Contents.Source = "data:," + dataurl.Escape(data)
+		mode := int(fi.Mode().Perm())
+		file.Mode = &mode
 		cfg.Storage.Files = append(cfg.Storage.Files, file)
 	}
 
@@ -167,8 +176,10 @@ func buildTemplate2_2(src *TemplateSource, baseDir string) (*ign22.Config, error
 			return nil, errors.New("non-absolute filename: " + fname)
 		}
 		var file ign22.File
+		file.Filesystem = "root"
 		file.Path = fname
 		file.Contents.Source = remoteFile.URL
+		file.Mode = remoteFile.Mode
 		cfg.Storage.Files = append(cfg.Storage.Files, file)
 	}
 
@@ -255,9 +266,16 @@ func buildTemplate2_3(src *TemplateSource, baseDir string) (*ign23.Config, error
 		if err != nil {
 			return nil, err
 		}
+		fi, err := os.Stat(target)
+		if err != nil {
+			return nil, err
+		}
 		var file ign23.File
+		file.Filesystem = "root"
 		file.Path = fname
 		file.Contents.Source = "data:," + dataurl.Escape(data)
+		mode := int(fi.Mode().Perm())
+		file.Mode = &mode
 		cfg.Storage.Files = append(cfg.Storage.Files, file)
 	}
 
@@ -268,8 +286,10 @@ func buildTemplate2_3(src *TemplateSource, baseDir string) (*ign23.Config, error
 			return nil, errors.New("non-absolute filename: " + fname)
 		}
 		var file ign23.File
+		file.Filesystem = "root"
 		file.Path = fname
 		file.Contents.Source = remoteFile.URL
+		file.Mode = remoteFile.Mode
 		cfg.Storage.Files = append(cfg.Storage.Files, file)
 	}
 

--- a/client/ignition_template_test.go
+++ b/client/ignition_template_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 
 	ign23 "github.com/coreos/ignition/config/v2_3/types"
@@ -54,13 +55,30 @@ func testBuildIgnitionTemplate2_3(t *testing.T) {
 			SSHAuthorizedKeys: []ign23.SSHAuthorizedKey{"key1"},
 		},
 	}
-	expectedFiles := make([]ign23.File, 3)
+	fi0, err := os.Stat("../testdata/base/files/etc/rack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fi3, err := os.Stat("../testdata/test/files/etc/hostname")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedFiles := make([]ign23.File, 4)
+	expectedFiles[0].Filesystem = "root"
 	expectedFiles[0].Path = "/etc/rack"
 	expectedFiles[0].Contents.Source = "data:," + dataurl.EscapeString("{{ .Spec.Rack }}\n")
+	expectedFiles[0].Mode = intPtr(int(fi0.Mode().Perm()))
+	expectedFiles[1].Filesystem = "root"
 	expectedFiles[1].Path = "/tmp/foo.img"
 	expectedFiles[1].Contents.Source = "{{ MyURL }}/api/v1/assets/foo.img"
-	expectedFiles[2].Path = "/etc/hostname"
-	expectedFiles[2].Contents.Source = "data:," + dataurl.EscapeString("{{ .Spec.Serial }}\n")
+	expectedFiles[2].Filesystem = "root"
+	expectedFiles[2].Path = "/opt/sbin/bar"
+	expectedFiles[2].Contents.Source = "{{ MyURL }}/api/v1/assets/bar"
+	expectedFiles[2].Mode = intPtr(0755)
+	expectedFiles[3].Filesystem = "root"
+	expectedFiles[3].Path = "/etc/hostname"
+	expectedFiles[3].Contents.Source = "data:," + dataurl.EscapeString("{{ .Spec.Serial }}\n")
+	expectedFiles[3].Mode = intPtr(int(fi3.Mode().Perm()))
 	expected.Storage.Files = expectedFiles
 	expected.Networkd.Units = []ign23.Networkdunit{
 		{

--- a/docs/ignition_template.md
+++ b/docs/ignition_template.md
@@ -21,6 +21,7 @@ files:
 remote_files:
   - name: /tmp/some.img
     url: "{{ MyURL }}/v1/assets/some.img"
+    mode: 0755
 systemd:
   - name: chronyd.service
     enabled: true
@@ -38,7 +39,8 @@ Field descriptions:
 * `passwd`: A YAML filename that contains YAML encoded ignition's [`passwd` object](https://coreos.com/ignition/docs/latest/configuration-v2_3.html).
 * `files`: List of filenames to be provisioned.  
     The file contents are read from files under `files/` sub directory.
-* `remote_files`: List of remote files to be provisioned.
+* `remote_files`: List of remote files to be provisioned.  
+    `mode` is optional.  It should be an octal UNIX file permission bits.
 * `systemd`: List of systemd unit files to be provisioned.  
     The unit contents are read from files under `systemd/` sub directory.  
     If `enabled` is true, the unit will be enabled.  

--- a/mtest/ignitions/files/etc/hostname
+++ b/mtest/ignitions/files/etc/hostname
@@ -1,0 +1,1 @@
+rack{{ .Spec.Rack }}-{{ .Spec.Role }}{{ .Spec.IndexInRack }}

--- a/mtest/ignitions/systemd/foo.service
+++ b/mtest/ignitions/systemd/foo.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=foo
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/echo aaa
+
+[Install]
+WantedBy=multi-user.target

--- a/mtest/ignitions/worker.yml
+++ b/mtest/ignitions/worker.yml
@@ -1,3 +1,8 @@
 passwd: passwd.yml
+files:
+  - /etc/hostname
 networkd:
-        - 10-eth0.network
+  - 10-eth0.network
+systemd:
+  - name: foo.service
+    enabled: true

--- a/testdata/base/base.yml
+++ b/testdata/base/base.yml
@@ -5,6 +5,9 @@ files:
 remote_files:
   - name: /tmp/foo.img
     url: "{{ MyURL }}/api/v1/assets/foo.img"
+  - name: /opt/sbin/bar
+    url: "{{ MyURL }}/api/v1/assets/bar"
+    mode: 0755
 systemd:
   - name: chronyd.service
     enabled: true


### PR DESCRIPTION
Sabakan 2.0.0 degraded ignition template system due to missing
mandatory properties for files such as "filesystem" or "mode".

That was not tested in multi-host test.

This commit fixes the degradation and add tests for them.