### PR TITLE
Allow some state transitions.

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -53,7 +53,7 @@ External controllers are responsible to:
 
 ### Transition constraints
 
-* **Uninitialized** can transition to **Healthy**, **Unhealthy**, **Unreachable** or **Retiring**.
+* **Uninitialized** can transition to **Healthy** or **Retiring**.
 * **Healthy** can transition to **Unhealthy**, **Unreachable**, **Updating** or **Retiring**.
 * **Unhealthy** can transition to **Healthy**, **Unreachable**, **Updating** or **Retiring**.
 * **Unreachable** can transition to **Healthy**, **Unhealthy**, **Updating** or **Retiring**.
@@ -73,4 +73,4 @@ And only such **Retired** machines can be removed from sabakan.
 
 ### Transition diagram
 
-![state transition diagram](https://www.plantuml.com/plantuml/png/bPF1JiCm38RlUGgVaIhkEQ0XE712QD9EY8FNU6lKrgbSZwayFIbqAQacgjtS-8__pwczwHL5JsrZtky-e73XpCK3xDYpLu-D_o9diYyeOlw5iD5gk9BPSVLFJWZB2lSDNSbkIRruFbfufh91BmGo7HcpwnngZA0GVwnqYMZXyQ0a8BGFGOsP-7AYiR1IgJqW0ua4IRe5dOLNqdEG6axpOIPUmFvbJR9J5uKNS9kY--q8EKQW5K4RoticOnBdca4kdEnil566Jn8uI6Zd3fCulTnwexd1BHsa6eifoSzJ_JoprdMIteXbBbLd2t8s1cryh_v7wtnV0t4fGwS-CDGqJDVIw6RJzYRKeL3ca-JJ3iLzil24338QPThVVzJZ7cjaio5sSG6_0G00)
+![state transition diagram](https://www.plantuml.com/plantuml/png/bPEnJiGm38RtF8Ldf8ez0pe40nD29zs46Dp6TusQ9fNhSYfFJ-ZbI8cGgjkS-8l_tt6o6mLPfjwfzxiFg4mu--e13jvwAnQT_IAZ_goWYlaNGYVj_4zcJsBP-fE6PseSMYRWjANKOJ0eCOAAxQcLKaZ3ur68WQaEGPHAAb0jO7jP_HGMQcG4z43CWGkE2PiMQqSQNadEWJkOykOQBiskl6Pi6Y9uDQv_e_lzOZ9682r17yjRJqebdvi21PZaT3pHX4zYE7BeSuSPpZUtqMWXS4C7kKOnwxoV9r9ajhlEw6ssrBLgbY2ZOz37-neNrjYn0_8DpuFOuA6ZEHrBZxDuRMzC0pAjTJAUVaBy5HgUq0ClGclsCgCHQ-pGgnrvC_Nk6m00)

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -53,10 +53,10 @@ External controllers are responsible to:
 
 ### Transition constraints
 
-* **Uninitialized** can transition to **Healthy** or **Retiring**.
+* **Uninitialized** can transition to **Healthy**, **Unhealthy**, **Unreachable** or **Retiring**.
 * **Healthy** can transition to **Unhealthy**, **Unreachable**, **Updating** or **Retiring**.
-* **Unhealthy** can transition to **Healthy**, **Unreachable** or **Retiring**.
-* **Unreachable** can transition to **Healthy** or **Retiring**.
+* **Unhealthy** can transition to **Healthy**, **Unreachable**, **Updating** or **Retiring**.
+* **Unreachable** can transition to **Healthy**, **Unhealthy**, **Updating** or **Retiring**.
 * **Updating** can transition to **Uninitialized** after restarting.
 * **Retiring** can transition to **Retired** when it has no disk encryption keys.
 * **Retired** can transition to **Uninitialized**.
@@ -73,4 +73,4 @@ And only such **Retired** machines can be removed from sabakan.
 
 ### Transition diagram
 
-![state transition diagram](http://www.plantuml.com/plantuml/svg/ZPAzQiD0381tFONcWkdkeQIqGwTI0fbA1yMdv0xREYCh3UdJz-mut3K4ckrE-lJ3XrQZaTgXx-3puGih5uzIFU56WWGBr8KVTl3dXrNAlp5rvaytCckse47sDRvoqr5GHbr204lP36x4dtyJQTpOY2J8gb6lE6LgF6qxhl6TxHYrnKCEbl3rz69unWx3r7LmP3DuUJskUHlZz4BpZ7rg7uG1BdcihhtK-BmpLjIvC97Yxrgb1BFBEbKqyPiLTnhxxAA0DUoztQC42gASKSR_MnBWaimaksdBFcqvpf9S65jaQVGqM8Y2BPy05lAMhm_bWPHBmHbVJY-TOOql9AZpe98zcnbfIoq9h5XSkjjV)
+![state transition diagram](https://www.plantuml.com/plantuml/png/bPF1JiCm38RlUGgVaIhkEQ0XE712QD9EY8FNU6lKrgbSZwayFIbqAQacgjtS-8__pwczwHL5JsrZtky-e73XpCK3xDYpLu-D_o9diYyeOlw5iD5gk9BPSVLFJWZB2lSDNSbkIRruFbfufh91BmGo7HcpwnngZA0GVwnqYMZXyQ0a8BGFGOsP-7AYiR1IgJqW0ua4IRe5dOLNqdEG6axpOIPUmFvbJR9J5uKNS9kY--q8EKQW5K4RoticOnBdca4kdEnil566Jn8uI6Zd3fCulTnwexd1BHsa6eifoSzJ_JoprdMIteXbBbLd2t8s1cryh_v7wtnV0t4fGwS-CDGqJDVIw6RJzYRKeL3ca-JJ3iLzil24338QPThVVzJZ7cjaio5sSG6_0G00)

--- a/machines.go
+++ b/machines.go
@@ -78,7 +78,7 @@ var (
 	reValidLabelName     = regexp.MustCompile(`^[a-z0-9A-Z]([a-z0-9A-Z_.-]{0,61}[a-z0-9A-Z])?$`)
 	reValidLabelVal      = regexp.MustCompile(`^[a-z0-9A-Z]([a-z0-9A-Z_.-]{0,61}[a-z0-9A-Z])?$`)
 	permittedTransitions = map[MachineState][]MachineState{
-		StateUninitialized: {StateHealthy, StateUnhealthy, StateUnreachable, StateRetiring},
+		StateUninitialized: {StateHealthy, StateRetiring},
 		StateHealthy:       {StateUnhealthy, StateUnreachable, StateUpdating, StateRetiring},
 		StateUnhealthy:     {StateHealthy, StateUnreachable, StateUpdating, StateRetiring},
 		StateUnreachable:   {StateHealthy, StateUnhealthy, StateUpdating, StateRetiring},

--- a/machines.go
+++ b/machines.go
@@ -78,10 +78,10 @@ var (
 	reValidLabelName     = regexp.MustCompile(`^[a-z0-9A-Z]([a-z0-9A-Z_.-]{0,61}[a-z0-9A-Z])?$`)
 	reValidLabelVal      = regexp.MustCompile(`^[a-z0-9A-Z]([a-z0-9A-Z_.-]{0,61}[a-z0-9A-Z])?$`)
 	permittedTransitions = map[MachineState][]MachineState{
-		StateUninitialized: {StateHealthy, StateRetiring},
+		StateUninitialized: {StateHealthy, StateUnhealthy, StateUnreachable, StateRetiring},
 		StateHealthy:       {StateUnhealthy, StateUnreachable, StateUpdating, StateRetiring},
-		StateUnhealthy:     {StateHealthy, StateUnreachable, StateRetiring},
-		StateUnreachable:   {StateHealthy, StateRetiring},
+		StateUnhealthy:     {StateHealthy, StateUnreachable, StateUpdating, StateRetiring},
+		StateUnreachable:   {StateHealthy, StateUnhealthy, StateUpdating, StateRetiring},
 		StateUpdating:      {StateUninitialized},
 		StateRetiring:      {StateRetired},
 		StateRetired:       {StateUninitialized},

--- a/web/state_test.go
+++ b/web/state_test.go
@@ -68,8 +68,8 @@ func testStatePutFromUninitialized(t *testing.T) {
 	testData := []testTransition{
 		{"uninitialized", 200},
 		{"healthy", 200},
-		{"unhealthy", 500},
-		{"unreachable", 500},
+		{"unhealthy", 200},
+		{"unreachable", 200},
 		{"updating", 500},
 		{"retiring", 200},
 		{"retired", 500},
@@ -134,7 +134,7 @@ func testStatePutFromUnhealthy(t *testing.T) {
 		{"healthy", 200},
 		{"unhealthy", 200},
 		{"unreachable", 200},
-		{"updating", 500},
+		{"updating", 200},
 		{"retiring", 200},
 		{"retired", 500},
 	}
@@ -165,9 +165,9 @@ func testStatePutFromUnreachable(t *testing.T) {
 	testData := []testTransition{
 		{"uninitialized", 500},
 		{"healthy", 200},
-		{"unhealthy", 500},
+		{"unhealthy", 200},
 		{"unreachable", 200},
-		{"updating", 500},
+		{"updating", 200},
 		{"retiring", 200},
 		{"retired", 500},
 	}

--- a/web/state_test.go
+++ b/web/state_test.go
@@ -68,8 +68,8 @@ func testStatePutFromUninitialized(t *testing.T) {
 	testData := []testTransition{
 		{"uninitialized", 200},
 		{"healthy", 200},
-		{"unhealthy", 200},
-		{"unreachable", 200},
+		{"unhealthy", 500},
+		{"unreachable", 500},
 		{"updating", 500},
 		{"retiring", 200},
 		{"retired", 500},


### PR DESCRIPTION
Allow following state transitions.
- Unhealthy --> Updating
- Unreachable --> Updating
    - To restart Unhealthy, Unreachable equipment using Updating state.
- Unreachable --> Unhealthy
    - If Unhealthy equipment temporarily becomes Unreachable, it will be stuck in the Unreachable state
- Uninitialized --> Unhealthy
- Uninitialized --> Unreachable
    - To prevent Unhealthy or Unreachable equipment from getting stuck in the Uninitialized state after a state transition from Updating to Uninitialized. 
    - If this change is made, it could cause an immediate transition from Uninitialized to Unhealthy or Unreachable. This is temporary and I see no problem as it will be pulled back to the correct state by the external controller.



Signed-off-by: kouki <kouworld0123@gmail.com>