### PR TITLE
Fix release workflow to run on git repository

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,9 @@ jobs:
     name: Release GitHub
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `gh` command requires any one of a `GH_REPO` environment variable,
a `--repo` option, or a local git repository.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
